### PR TITLE
Replace biome imagery with local illustrations and add built-in TTS

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -37,9 +37,8 @@ footer {
 }
 
 header {
-  background: linear-gradient(135deg, rgba(30, 109, 93, 0.9), rgba(35, 49, 63, 0.8)),
-    url('https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1600&q=80')
-      center/cover;
+  background: linear-gradient(135deg, rgba(43, 111, 85, 0.92), rgba(24, 59, 45, 0.78)),
+    url('../img/biomes/home.svg') center/cover;
   color: #fff;
   text-align: center;
   padding: 3rem 1rem 4rem;
@@ -77,20 +76,9 @@ header p {
   box-shadow: var(--shadow);
   overflow: hidden;
   transition: transform 0.25s ease, box-shadow 0.25s ease;
-  position: relative;
-  min-height: 240px;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
-}
-
-.card::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.3);
-  opacity: 0;
-  transition: opacity 0.25s ease;
+  min-height: 280px;
 }
 
 .card:hover,
@@ -99,22 +87,37 @@ header p {
   box-shadow: 0 16px 30px rgba(0, 0, 0, 0.18);
 }
 
-.card:hover::before,
-.card:focus-within::before {
-  opacity: 1;
+.card-image {
+  padding: 1.75rem 1.75rem 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card-image img {
+  width: 100%;
+  max-width: 280px;
+  max-height: 170px;
+  object-fit: contain;
 }
 
 .card-content {
-  position: relative;
-  padding: 1.5rem;
-  color: #fff;
-  z-index: 1;
+  padding: 1.75rem 1.75rem 2.25rem;
+  color: var(--text-color);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  flex: 1;
+  justify-content: center;
 }
 
 .card h2,
 .card h3 {
   font-size: 1.6rem;
   margin-bottom: 0.5rem;
+  color: var(--primary-color);
 }
 
 .card p {
@@ -212,6 +215,13 @@ header p {
 
 .speak-button:hover {
   transform: translateY(-2px);
+}
+
+.speak-button.is-speaking {
+  cursor: wait;
+  opacity: 0.75;
+  box-shadow: 0 6px 10px rgba(249, 168, 38, 0.28);
+  transform: none;
 }
 
 .biome-badge {

--- a/assets/img/animals/desert/arabian-oryx.svg
+++ b/assets/img/animals/desert/arabian-oryx.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Arabian Oryx">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#d9822a" />
+      <stop offset="100%" stop-color="#a34f16" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦌
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Arabian Oryx
+  </text>
+</svg>

--- a/assets/img/animals/desert/bark-scorpion.svg
+++ b/assets/img/animals/desert/bark-scorpion.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Bark Scorpion">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#d9822a" />
+      <stop offset="100%" stop-color="#a34f16" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦂
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Bark Scorpion
+  </text>
+</svg>

--- a/assets/img/animals/desert/desert-tortoise.svg
+++ b/assets/img/animals/desert/desert-tortoise.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Desert Tortoise">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#d9822a" />
+      <stop offset="100%" stop-color="#a34f16" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐢
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Desert Tortoise
+  </text>
+</svg>

--- a/assets/img/animals/desert/dromedary-camel.svg
+++ b/assets/img/animals/desert/dromedary-camel.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Dromedary Camel">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#d9822a" />
+      <stop offset="100%" stop-color="#a34f16" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐪
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Dromedary Camel
+  </text>
+</svg>

--- a/assets/img/animals/desert/egyptian-vulture.svg
+++ b/assets/img/animals/desert/egyptian-vulture.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Egyptian Vulture">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#d9822a" />
+      <stop offset="100%" stop-color="#a34f16" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦅
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Egyptian Vulture
+  </text>
+</svg>

--- a/assets/img/animals/desert/fennec-fox.svg
+++ b/assets/img/animals/desert/fennec-fox.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Fennec Fox">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#d9822a" />
+      <stop offset="100%" stop-color="#a34f16" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦊
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Fennec Fox
+  </text>
+</svg>

--- a/assets/img/animals/desert/gila-monster.svg
+++ b/assets/img/animals/desert/gila-monster.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Gila Monster">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#d9822a" />
+      <stop offset="100%" stop-color="#a34f16" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦎
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Gila Monster
+  </text>
+</svg>

--- a/assets/img/animals/desert/horned-lizard.svg
+++ b/assets/img/animals/desert/horned-lizard.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Horned Lizard">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#d9822a" />
+      <stop offset="100%" stop-color="#a34f16" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦎
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Horned Lizard
+  </text>
+</svg>

--- a/assets/img/animals/desert/jerboa.svg
+++ b/assets/img/animals/desert/jerboa.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Jerboa">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#d9822a" />
+      <stop offset="100%" stop-color="#a34f16" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐹
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Jerboa
+  </text>
+</svg>

--- a/assets/img/animals/desert/kangaroo-rat.svg
+++ b/assets/img/animals/desert/kangaroo-rat.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Kangaroo Rat">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#d9822a" />
+      <stop offset="100%" stop-color="#a34f16" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐭
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Kangaroo Rat
+  </text>
+</svg>

--- a/assets/img/animals/desert/roadrunner.svg
+++ b/assets/img/animals/desert/roadrunner.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Roadrunner">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#d9822a" />
+      <stop offset="100%" stop-color="#a34f16" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐦
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Roadrunner
+  </text>
+</svg>

--- a/assets/img/animals/desert/sidewinder-rattlesnake.svg
+++ b/assets/img/animals/desert/sidewinder-rattlesnake.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Sidewinder Rattlesnake">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#d9822a" />
+      <stop offset="100%" stop-color="#a34f16" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐍
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Sidewinder Rattlesnake
+  </text>
+</svg>

--- a/assets/img/animals/rainforest/amazon-river-dolphin.svg
+++ b/assets/img/animals/rainforest/amazon-river-dolphin.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Amazon River Dolphin">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c5a3a" />
+      <stop offset="100%" stop-color="#05301b" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐬
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Amazon River Dolphin
+  </text>
+</svg>

--- a/assets/img/animals/rainforest/capuchin-monkey.svg
+++ b/assets/img/animals/rainforest/capuchin-monkey.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Capuchin Monkey">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c5a3a" />
+      <stop offset="100%" stop-color="#05301b" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐒
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Capuchin Monkey
+  </text>
+</svg>

--- a/assets/img/animals/rainforest/green-anaconda.svg
+++ b/assets/img/animals/rainforest/green-anaconda.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Green Anaconda">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c5a3a" />
+      <stop offset="100%" stop-color="#05301b" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐍
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Green Anaconda
+  </text>
+</svg>

--- a/assets/img/animals/rainforest/harpy-eagle.svg
+++ b/assets/img/animals/rainforest/harpy-eagle.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Harpy Eagle">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c5a3a" />
+      <stop offset="100%" stop-color="#05301b" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦅
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Harpy Eagle
+  </text>
+</svg>

--- a/assets/img/animals/rainforest/jaguar.svg
+++ b/assets/img/animals/rainforest/jaguar.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Jaguar">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c5a3a" />
+      <stop offset="100%" stop-color="#05301b" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐆
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Jaguar
+  </text>
+</svg>

--- a/assets/img/animals/rainforest/leaf-tailed-gecko.svg
+++ b/assets/img/animals/rainforest/leaf-tailed-gecko.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Leaf-Tailed Gecko">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c5a3a" />
+      <stop offset="100%" stop-color="#05301b" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦎
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Leaf-Tailed Gecko
+  </text>
+</svg>

--- a/assets/img/animals/rainforest/leafcutter-ant.svg
+++ b/assets/img/animals/rainforest/leafcutter-ant.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Leafcutter Ant">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c5a3a" />
+      <stop offset="100%" stop-color="#05301b" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐜
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Leafcutter Ant
+  </text>
+</svg>

--- a/assets/img/animals/rainforest/orangutan.svg
+++ b/assets/img/animals/rainforest/orangutan.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Orangutan">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c5a3a" />
+      <stop offset="100%" stop-color="#05301b" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦧
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Orangutan
+  </text>
+</svg>

--- a/assets/img/animals/rainforest/poison-dart-frog.svg
+++ b/assets/img/animals/rainforest/poison-dart-frog.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Poison Dart Frog">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c5a3a" />
+      <stop offset="100%" stop-color="#05301b" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐸
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Poison Dart Frog
+  </text>
+</svg>

--- a/assets/img/animals/rainforest/scarlet-macaw.svg
+++ b/assets/img/animals/rainforest/scarlet-macaw.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Scarlet Macaw">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c5a3a" />
+      <stop offset="100%" stop-color="#05301b" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦜
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Scarlet Macaw
+  </text>
+</svg>

--- a/assets/img/animals/rainforest/sloth.svg
+++ b/assets/img/animals/rainforest/sloth.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Sloth">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c5a3a" />
+      <stop offset="100%" stop-color="#05301b" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦥
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Sloth
+  </text>
+</svg>

--- a/assets/img/animals/rainforest/toucan.svg
+++ b/assets/img/animals/rainforest/toucan.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Toucan">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c5a3a" />
+      <stop offset="100%" stop-color="#05301b" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦜
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Toucan
+  </text>
+</svg>

--- a/assets/img/animals/savannah/african-elephant.svg
+++ b/assets/img/animals/savannah/african-elephant.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="African Elephant">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c47a18" />
+      <stop offset="100%" stop-color="#7a4510" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐘
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">African Elephant
+  </text>
+</svg>

--- a/assets/img/animals/savannah/african-wild-dog.svg
+++ b/assets/img/animals/savannah/african-wild-dog.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="African Wild Dog">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c47a18" />
+      <stop offset="100%" stop-color="#7a4510" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐕
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">African Wild Dog
+  </text>
+</svg>

--- a/assets/img/animals/savannah/cheetah.svg
+++ b/assets/img/animals/savannah/cheetah.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Cheetah">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c47a18" />
+      <stop offset="100%" stop-color="#7a4510" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐆
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Cheetah
+  </text>
+</svg>

--- a/assets/img/animals/savannah/giraffe.svg
+++ b/assets/img/animals/savannah/giraffe.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Giraffe">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c47a18" />
+      <stop offset="100%" stop-color="#7a4510" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦒
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Giraffe
+  </text>
+</svg>

--- a/assets/img/animals/savannah/hippopotamus.svg
+++ b/assets/img/animals/savannah/hippopotamus.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Hippopotamus">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c47a18" />
+      <stop offset="100%" stop-color="#7a4510" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦛
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Hippopotamus
+  </text>
+</svg>

--- a/assets/img/animals/savannah/lion.svg
+++ b/assets/img/animals/savannah/lion.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Lion">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c47a18" />
+      <stop offset="100%" stop-color="#7a4510" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦁
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Lion
+  </text>
+</svg>

--- a/assets/img/animals/savannah/meerkat.svg
+++ b/assets/img/animals/savannah/meerkat.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Meerkat">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c47a18" />
+      <stop offset="100%" stop-color="#7a4510" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐿️
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Meerkat
+  </text>
+</svg>

--- a/assets/img/animals/savannah/ostrich.svg
+++ b/assets/img/animals/savannah/ostrich.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Ostrich">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c47a18" />
+      <stop offset="100%" stop-color="#7a4510" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐦
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Ostrich
+  </text>
+</svg>

--- a/assets/img/animals/savannah/secretary-bird.svg
+++ b/assets/img/animals/savannah/secretary-bird.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Secretary Bird">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c47a18" />
+      <stop offset="100%" stop-color="#7a4510" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦅
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Secretary Bird
+  </text>
+</svg>

--- a/assets/img/animals/savannah/warthog.svg
+++ b/assets/img/animals/savannah/warthog.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Warthog">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c47a18" />
+      <stop offset="100%" stop-color="#7a4510" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐗
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Warthog
+  </text>
+</svg>

--- a/assets/img/animals/savannah/wildebeest.svg
+++ b/assets/img/animals/savannah/wildebeest.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Wildebeest">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c47a18" />
+      <stop offset="100%" stop-color="#7a4510" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐃
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Wildebeest
+  </text>
+</svg>

--- a/assets/img/animals/savannah/zebra.svg
+++ b/assets/img/animals/savannah/zebra.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Zebra">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c47a18" />
+      <stop offset="100%" stop-color="#7a4510" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦓
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Zebra
+  </text>
+</svg>

--- a/assets/img/animals/tundra/arctic-fox.svg
+++ b/assets/img/animals/tundra/arctic-fox.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Arctic Fox">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3b6ca1" />
+      <stop offset="100%" stop-color="#1b3653" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦊
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Arctic Fox
+  </text>
+</svg>

--- a/assets/img/animals/tundra/arctic-hare.svg
+++ b/assets/img/animals/tundra/arctic-hare.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Arctic Hare">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3b6ca1" />
+      <stop offset="100%" stop-color="#1b3653" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐇
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Arctic Hare
+  </text>
+</svg>

--- a/assets/img/animals/tundra/arctic-wolf.svg
+++ b/assets/img/animals/tundra/arctic-wolf.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Arctic Wolf">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3b6ca1" />
+      <stop offset="100%" stop-color="#1b3653" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐺
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Arctic Wolf
+  </text>
+</svg>

--- a/assets/img/animals/tundra/atlantic-puffin.svg
+++ b/assets/img/animals/tundra/atlantic-puffin.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Atlantic Puffin">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3b6ca1" />
+      <stop offset="100%" stop-color="#1b3653" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐧
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Atlantic Puffin
+  </text>
+</svg>

--- a/assets/img/animals/tundra/caribou.svg
+++ b/assets/img/animals/tundra/caribou.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Caribou">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3b6ca1" />
+      <stop offset="100%" stop-color="#1b3653" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦌
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Caribou
+  </text>
+</svg>

--- a/assets/img/animals/tundra/lemming.svg
+++ b/assets/img/animals/tundra/lemming.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Lemming">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3b6ca1" />
+      <stop offset="100%" stop-color="#1b3653" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐭
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Lemming
+  </text>
+</svg>

--- a/assets/img/animals/tundra/musk-ox.svg
+++ b/assets/img/animals/tundra/musk-ox.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Musk Ox">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3b6ca1" />
+      <stop offset="100%" stop-color="#1b3653" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐂
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Musk Ox
+  </text>
+</svg>

--- a/assets/img/animals/tundra/narwhal.svg
+++ b/assets/img/animals/tundra/narwhal.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Narwhal">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3b6ca1" />
+      <stop offset="100%" stop-color="#1b3653" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐋
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Narwhal
+  </text>
+</svg>

--- a/assets/img/animals/tundra/polar-bear.svg
+++ b/assets/img/animals/tundra/polar-bear.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Polar Bear">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3b6ca1" />
+      <stop offset="100%" stop-color="#1b3653" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🐻‍❄️
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Polar Bear
+  </text>
+</svg>

--- a/assets/img/animals/tundra/ringed-seal.svg
+++ b/assets/img/animals/tundra/ringed-seal.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Ringed Seal">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3b6ca1" />
+      <stop offset="100%" stop-color="#1b3653" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦭
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Ringed Seal
+  </text>
+</svg>

--- a/assets/img/animals/tundra/snowy-owl.svg
+++ b/assets/img/animals/tundra/snowy-owl.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Snowy Owl">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3b6ca1" />
+      <stop offset="100%" stop-color="#1b3653" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦉
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Snowy Owl
+  </text>
+</svg>

--- a/assets/img/animals/tundra/walrus.svg
+++ b/assets/img/animals/tundra/walrus.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Walrus">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3b6ca1" />
+      <stop offset="100%" stop-color="#1b3653" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🦭
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Walrus
+  </text>
+</svg>

--- a/assets/img/biomes/desert.svg
+++ b/assets/img/biomes/desert.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Desert">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#d9822a" />
+      <stop offset="100%" stop-color="#a34f16" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🌵
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Desert
+  </text>
+</svg>

--- a/assets/img/biomes/home.svg
+++ b/assets/img/biomes/home.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Biome Adventure">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2b6f55" />
+      <stop offset="100%" stop-color="#183b2d" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🌍
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Biome Adventure
+  </text>
+</svg>

--- a/assets/img/biomes/rainforest.svg
+++ b/assets/img/biomes/rainforest.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Rainforest">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c5a3a" />
+      <stop offset="100%" stop-color="#05301b" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🌴
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Rainforest
+  </text>
+</svg>

--- a/assets/img/biomes/savannah.svg
+++ b/assets/img/biomes/savannah.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Savannah">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c47a18" />
+      <stop offset="100%" stop-color="#7a4510" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">🌾
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Savannah
+  </text>
+</svg>

--- a/assets/img/biomes/tundra.svg
+++ b/assets/img/biomes/tundra.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Tundra">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3b6ca1" />
+      <stop offset="100%" stop-color="#1b3653" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" rx="60" />
+  <circle cx="900" cy="140" r="160" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="260" cy="620" r="220" fill="rgba(255, 255, 255, 0.07)" />
+  <ellipse cx="600" cy="480" rx="360" ry="240" fill="url(#glow)" />
+  <text x="600" y="420" font-size="260" text-anchor="middle" dominant-baseline="middle" font-family="'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif">❄️
+  </text>
+  <text x="600" y="640" font-size="88" text-anchor="middle" fill="rgba(255,255,255,0.94)" font-family="'Baloo 2', 'Nunito', 'Poppins', sans-serif" font-weight="700">Tundra
+  </text>
+</svg>

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,15 +1,139 @@
+const ME_SPEAK_SCRIPT = 'https://cdn.jsdelivr.net/npm/mespeak/mespeak.min.js';
+const ME_SPEAK_CONFIG = 'https://cdn.jsdelivr.net/npm/mespeak/mespeak_config.json';
+const ME_SPEAK_VOICE = 'https://cdn.jsdelivr.net/npm/mespeak/voices/en/en.json';
+
+let meSpeakInitPromise = null;
+
+function ensureMeSpeakReady() {
+  if (
+    window.meSpeak &&
+    typeof window.meSpeak.isConfigLoaded === 'function' &&
+    window.meSpeak.isConfigLoaded() &&
+    typeof window.meSpeak.isVoiceLoaded === 'function' &&
+    window.meSpeak.isVoiceLoaded('en/en')
+  ) {
+    return Promise.resolve(true);
+  }
+
+  if (meSpeakInitPromise) {
+    return meSpeakInitPromise;
+  }
+
+  meSpeakInitPromise = new Promise((resolve) => {
+    const script = document.createElement('script');
+    script.src = ME_SPEAK_SCRIPT;
+    script.async = true;
+
+    script.onload = () => {
+      if (!window.meSpeak) {
+        meSpeakInitPromise = null;
+        resolve(false);
+        return;
+      }
+
+      Promise.all([
+        fetch(ME_SPEAK_CONFIG).then((response) => {
+          if (!response.ok) {
+            throw new Error('Failed to load meSpeak config');
+          }
+          return response.json();
+        }),
+        fetch(ME_SPEAK_VOICE).then((response) => {
+          if (!response.ok) {
+            throw new Error('Failed to load meSpeak voice');
+          }
+          return response.json();
+        }),
+      ])
+        .then(([config, voice]) => {
+          window.meSpeak.loadConfig(config);
+          window.meSpeak.loadVoice(voice);
+          resolve(true);
+        })
+        .catch((error) => {
+          console.warn('Unable to initialise meSpeak:', error);
+          meSpeakInitPromise = null;
+          resolve(false);
+        });
+    };
+
+    script.onerror = () => {
+      console.warn('Unable to load meSpeak script');
+      meSpeakInitPromise = null;
+      resolve(false);
+    };
+
+    document.head.appendChild(script);
+  });
+
+  return meSpeakInitPromise;
+}
+
+function speakWithMeSpeak(text) {
+  return ensureMeSpeakReady().then((ready) => {
+    if (!ready || !window.meSpeak) {
+      return false;
+    }
+
+    try {
+      window.meSpeak.stop();
+      window.meSpeak.speak(text, {
+        amplitude: 100,
+        wordgap: 4,
+        pitch: 55,
+        speed: 165,
+        voice: 'en/en',
+      });
+      return true;
+    } catch (error) {
+      console.warn('meSpeak could not play audio:', error);
+      return false;
+    }
+  });
+}
+
+function speakWithBrowser(text) {
+  if (!('speechSynthesis' in window)) {
+    console.warn('Browser speech synthesis is unavailable.');
+    return;
+  }
+
+  window.speechSynthesis.cancel();
+  const utterance = new SpeechSynthesisUtterance(text);
+  utterance.lang = 'en-US';
+  utterance.rate = 0.95;
+  utterance.pitch = 1;
+  window.speechSynthesis.speak(utterance);
+}
+
+function setButtonBusy(button, busy) {
+  button.disabled = busy;
+  button.classList.toggle('is-speaking', busy);
+  button.setAttribute('aria-busy', busy ? 'true' : 'false');
+}
+
 function setupSpeechButtons() {
   const buttons = document.querySelectorAll('.speak-button');
   buttons.forEach((button) => {
     button.addEventListener('click', () => {
       const text = button.getAttribute('data-speech');
-      if (!text) return;
+      if (!text) {
+        return;
+      }
 
-      window.speechSynthesis.cancel();
-      const utterance = new SpeechSynthesisUtterance(text);
-      utterance.lang = 'en-US';
-      utterance.rate = 1;
-      window.speechSynthesis.speak(utterance);
+      setButtonBusy(button, true);
+
+      speakWithMeSpeak(text)
+        .then((played) => {
+          if (!played) {
+            speakWithBrowser(text);
+          }
+        })
+        .finally(() => {
+          setTimeout(() => {
+            setButtonBusy(button, false);
+          }, 400);
+        });
     });
   });
 }

--- a/biomes/desert/arabian-oryx.html
+++ b/biomes/desert/arabian-oryx.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(187, 120, 32, 0.9), rgba(102, 58, 14, 0.75)),
-        url('https://images.unsplash.com/photo-1516528387618-afa90b13e000?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/desert.svg') center/cover;"
     >
       <h1>Arabian Oryx</h1>
       <p class="hero-text">Elegant desert antelope</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Desert Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1516528387618-afa90b13e000?auto=format&fit=crop&w=1200&q=80"
-          alt="Arabian oryx standing on sand"
+          src="../../assets/img/animals/desert/arabian-oryx.svg"
+          alt="Arabian Oryx illustration"
         />
         <div class="intro">
           <span class="biome-badge">Desert</span>

--- a/biomes/desert/bark-scorpion.html
+++ b/biomes/desert/bark-scorpion.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(187, 120, 32, 0.9), rgba(102, 58, 14, 0.75)),
-        url('https://images.unsplash.com/photo-1524593131171-1ffadbbe1535?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/desert.svg') center/cover;"
     >
       <h1>Bark Scorpion</h1>
       <p class="hero-text">Glowing night hunter</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Desert Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1524593131171-1ffadbbe1535?auto=format&fit=crop&w=1200&q=80"
-          alt="Bark scorpion glowing under light"
+          src="../../assets/img/animals/desert/bark-scorpion.svg"
+          alt="Bark Scorpion illustration"
         />
         <div class="intro">
           <span class="biome-badge">Desert</span>

--- a/biomes/desert/desert-tortoise.html
+++ b/biomes/desert/desert-tortoise.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(187, 120, 32, 0.9), rgba(102, 58, 14, 0.75)),
-        url('https://images.unsplash.com/photo-1518796745738-41048802f99a?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/desert.svg') center/cover;"
     >
       <h1>Desert Tortoise</h1>
       <p class="hero-text">Slow and steady survivor</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Desert Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1518796745738-41048802f99a?auto=format&fit=crop&w=1200&q=80"
-          alt="Desert tortoise walking on sand"
+          src="../../assets/img/animals/desert/desert-tortoise.svg"
+          alt="Desert Tortoise illustration"
         />
         <div class="intro">
           <span class="biome-badge">Desert</span>

--- a/biomes/desert/dromedary-camel.html
+++ b/biomes/desert/dromedary-camel.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(187, 120, 32, 0.9), rgba(102, 58, 14, 0.75)),
-        url('https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/desert.svg') center/cover;"
     >
       <h1>Dromedary Camel</h1>
       <p class="hero-text">Ship of the desert</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Desert Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1200&q=80"
-          alt="Camel walking in the desert"
+          src="../../assets/img/animals/desert/dromedary-camel.svg"
+          alt="Dromedary Camel illustration"
         />
         <div class="intro">
           <span class="biome-badge">Desert</span>

--- a/biomes/desert/egyptian-vulture.html
+++ b/biomes/desert/egyptian-vulture.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(187, 120, 32, 0.9), rgba(102, 58, 14, 0.75)),
-        url('https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/desert.svg') center/cover;"
     >
       <h1>Egyptian Vulture</h1>
       <p class="hero-text">Smart recycler</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Desert Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=1200&q=80"
-          alt="Egyptian vulture perched on rocks"
+          src="../../assets/img/animals/desert/egyptian-vulture.svg"
+          alt="Egyptian Vulture illustration"
         />
         <div class="intro">
           <span class="biome-badge">Desert</span>

--- a/biomes/desert/fennec-fox.html
+++ b/biomes/desert/fennec-fox.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(187, 120, 32, 0.9), rgba(102, 58, 14, 0.75)),
-        url('https://images.unsplash.com/photo-1529921879218-f0c0c2e9b481?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/desert.svg') center/cover;"
     >
       <h1>Fennec Fox</h1>
       <p class="hero-text">Little fox with big ears</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Desert Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1529921879218-f0c0c2e9b481?auto=format&fit=crop&w=1200&q=80"
-          alt="Fennec fox sitting on sand"
+          src="../../assets/img/animals/desert/fennec-fox.svg"
+          alt="Fennec Fox illustration"
         />
         <div class="intro">
           <span class="biome-badge">Desert</span>

--- a/biomes/desert/gila-monster.html
+++ b/biomes/desert/gila-monster.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(187, 120, 32, 0.9), rgba(102, 58, 14, 0.75)),
-        url('https://images.unsplash.com/photo-1526336024174-e58f5cdd8e13?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/desert.svg') center/cover;"
     >
       <h1>Gila Monster</h1>
       <p class="hero-text">Venomous desert lizard</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Desert Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1526336024174-e58f5cdd8e13?auto=format&fit=crop&w=1200&q=80"
-          alt="Gila monster on a rock"
+          src="../../assets/img/animals/desert/gila-monster.svg"
+          alt="Gila Monster illustration"
         />
         <div class="intro">
           <span class="biome-badge">Desert</span>

--- a/biomes/desert/horned-lizard.html
+++ b/biomes/desert/horned-lizard.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(187, 120, 32, 0.9), rgba(102, 58, 14, 0.75)),
-        url('https://images.unsplash.com/photo-1560807707-8cc77767d783?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/desert.svg') center/cover;"
     >
       <h1>Horned Lizard</h1>
       <p class="hero-text">Spiky desert pancake</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Desert Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1560807707-8cc77767d783?auto=format&fit=crop&w=1200&q=80"
-          alt="Horned lizard sitting on sand"
+          src="../../assets/img/animals/desert/horned-lizard.svg"
+          alt="Horned Lizard illustration"
         />
         <div class="intro">
           <span class="biome-badge">Desert</span>

--- a/biomes/desert/index.html
+++ b/biomes/desert/index.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(187, 120, 32, 0.9), rgba(102, 58, 14, 0.75)),
-        url('https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/desert.svg') center/cover;"
     >
       <h1>Desert Animals</h1>
       <p class="hero-text">
@@ -25,73 +25,109 @@
     <main class="container">
       <a class="back-link" href="../../index.html">← Back to Biome Adventure</a>
       <div class="animal-grid">
-        <a class="card" href="fennec-fox.html" style="background: url('https://images.unsplash.com/photo-1529921879218-f0c0c2e9b481?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="fennec-fox.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/desert/fennec-fox.svg" alt="Fennec Fox illustration" />
+          </div>
           <div class="card-content">
             <h3>Fennec Fox</h3>
             <p>Big-eared foxes that stay cool.</p>
           </div>
         </a>
-        <a class="card" href="dromedary-camel.html" style="background: url('https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="dromedary-camel.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/desert/dromedary-camel.svg" alt="Dromedary Camel illustration" />
+          </div>
           <div class="card-content">
             <h3>Dromedary Camel</h3>
             <p>One-humped travelers with water-saving humps.</p>
           </div>
         </a>
-        <a class="card" href="gila-monster.html" style="background: url('https://images.unsplash.com/photo-1526336024174-e58f5cdd8e13?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="gila-monster.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/desert/gila-monster.svg" alt="Gila Monster illustration" />
+          </div>
           <div class="card-content">
             <h3>Gila Monster</h3>
             <p>Slow lizards with venomous bites.</p>
           </div>
         </a>
-        <a class="card" href="roadrunner.html" style="background: url('https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="roadrunner.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/desert/roadrunner.svg" alt="Roadrunner illustration" />
+          </div>
           <div class="card-content">
             <h3>Roadrunner</h3>
             <p>Speedy birds who race the sun.</p>
           </div>
         </a>
-        <a class="card" href="horned-lizard.html" style="background: url('https://images.unsplash.com/photo-1560807707-8cc77767d783?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="horned-lizard.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/desert/horned-lizard.svg" alt="Horned Lizard illustration" />
+          </div>
           <div class="card-content">
             <h3>Horned Lizard</h3>
             <p>Spiky reptiles with desert disguises.</p>
           </div>
         </a>
-        <a class="card" href="desert-tortoise.html" style="background: url('https://images.unsplash.com/photo-1518796745738-41048802f99a?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="desert-tortoise.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/desert/desert-tortoise.svg" alt="Desert Tortoise illustration" />
+          </div>
           <div class="card-content">
             <h3>Desert Tortoise</h3>
             <p>Slow walkers with sturdy shells.</p>
           </div>
         </a>
-        <a class="card" href="bark-scorpion.html" style="background: url('https://images.unsplash.com/photo-1524593131171-1ffadbbe1535?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="bark-scorpion.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/desert/bark-scorpion.svg" alt="Bark Scorpion illustration" />
+          </div>
           <div class="card-content">
             <h3>Bark Scorpion</h3>
             <p>Glowing hunters of the night.</p>
           </div>
         </a>
-        <a class="card" href="kangaroo-rat.html" style="background: url('https://images.unsplash.com/photo-1589656966895-2f33e7653818?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="kangaroo-rat.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/desert/kangaroo-rat.svg" alt="Kangaroo Rat illustration" />
+          </div>
           <div class="card-content">
             <h3>Kangaroo Rat</h3>
             <p>Seed snackers that never need to drink.</p>
           </div>
         </a>
-        <a class="card" href="sidewinder-rattlesnake.html" style="background: url('https://images.unsplash.com/photo-1589483237065-716cac2220cf?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="sidewinder-rattlesnake.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/desert/sidewinder-rattlesnake.svg" alt="Sidewinder Rattlesnake illustration" />
+          </div>
           <div class="card-content">
             <h3>Sidewinder Rattlesnake</h3>
             <p>S-shaped sliders that stay cool.</p>
           </div>
         </a>
-        <a class="card" href="arabian-oryx.html" style="background: url('https://images.unsplash.com/photo-1516528387618-afa90b13e000?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="arabian-oryx.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/desert/arabian-oryx.svg" alt="Arabian Oryx illustration" />
+          </div>
           <div class="card-content">
             <h3>Arabian Oryx</h3>
             <p>Graceful antelopes with pale coats.</p>
           </div>
         </a>
-        <a class="card" href="egyptian-vulture.html" style="background: url('https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="egyptian-vulture.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/desert/egyptian-vulture.svg" alt="Egyptian Vulture illustration" />
+          </div>
           <div class="card-content">
             <h3>Egyptian Vulture</h3>
             <p>Feathered recyclers with clever tools.</p>
           </div>
         </a>
-        <a class="card" href="jerboa.html" style="background: url('https://images.unsplash.com/photo-1524593131171-1ffadbbe1535?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="jerboa.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/desert/jerboa.svg" alt="Jerboa illustration" />
+          </div>
           <div class="card-content">
             <h3>Jerboa</h3>
             <p>Tiny jumpers with springy legs.</p>

--- a/biomes/desert/jerboa.html
+++ b/biomes/desert/jerboa.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(187, 120, 32, 0.9), rgba(102, 58, 14, 0.75)),
-        url('https://images.unsplash.com/photo-1524593131171-1ffadbbe1535?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/desert.svg') center/cover;"
     >
       <h1>Jerboa</h1>
       <p class="hero-text">Mini jumper</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Desert Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1524593131171-1ffadbbe1535?auto=format&fit=crop&w=1200&q=80"
-          alt="Jerboa standing on hind legs"
+          src="../../assets/img/animals/desert/jerboa.svg"
+          alt="Jerboa illustration"
         />
         <div class="intro">
           <span class="biome-badge">Desert</span>

--- a/biomes/desert/kangaroo-rat.html
+++ b/biomes/desert/kangaroo-rat.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(187, 120, 32, 0.9), rgba(102, 58, 14, 0.75)),
-        url('https://images.unsplash.com/photo-1589656966895-2f33e7653818?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/desert.svg') center/cover;"
     >
       <h1>Kangaroo Rat</h1>
       <p class="hero-text">Desert hopper</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Desert Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1589656966895-2f33e7653818?auto=format&fit=crop&w=1200&q=80"
-          alt="Kangaroo rat standing on hind legs"
+          src="../../assets/img/animals/desert/kangaroo-rat.svg"
+          alt="Kangaroo Rat illustration"
         />
         <div class="intro">
           <span class="biome-badge">Desert</span>

--- a/biomes/desert/roadrunner.html
+++ b/biomes/desert/roadrunner.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(187, 120, 32, 0.9), rgba(102, 58, 14, 0.75)),
-        url('https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/desert.svg') center/cover;"
     >
       <h1>Roadrunner</h1>
       <p class="hero-text">Fast-footed bird</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Desert Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&w=1200&q=80"
-          alt="Roadrunner standing in the desert"
+          src="../../assets/img/animals/desert/roadrunner.svg"
+          alt="Roadrunner illustration"
         />
         <div class="intro">
           <span class="biome-badge">Desert</span>

--- a/biomes/desert/sidewinder-rattlesnake.html
+++ b/biomes/desert/sidewinder-rattlesnake.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(187, 120, 32, 0.9), rgba(102, 58, 14, 0.75)),
-        url('https://images.unsplash.com/photo-1589483237065-716cac2220cf?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/desert.svg') center/cover;"
     >
       <h1>Sidewinder Rattlesnake</h1>
       <p class="hero-text">Sideways slider</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Desert Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1589483237065-716cac2220cf?auto=format&fit=crop&w=1200&q=80"
-          alt="Sidewinder rattlesnake moving across sand"
+          src="../../assets/img/animals/desert/sidewinder-rattlesnake.svg"
+          alt="Sidewinder Rattlesnake illustration"
         />
         <div class="intro">
           <span class="biome-badge">Desert</span>

--- a/biomes/rainforest/amazon-river-dolphin.html
+++ b/biomes/rainforest/amazon-river-dolphin.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(20, 60, 40, 0.9), rgba(10, 30, 20, 0.75)),
-        url('https://images.unsplash.com/photo-1544552866-31fa0f0c7c79?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/rainforest.svg') center/cover;"
     >
       <h1>Amazon River Dolphin</h1>
       <p class="hero-text">Pink river explorer</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Rainforest Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1544552866-31fa0f0c7c79?auto=format&fit=crop&w=1200&q=80"
-          alt="Pink Amazon river dolphin swimming"
+          src="../../assets/img/animals/rainforest/amazon-river-dolphin.svg"
+          alt="Amazon River Dolphin illustration"
         />
         <div class="intro">
           <span class="biome-badge">Rainforest</span>

--- a/biomes/rainforest/capuchin-monkey.html
+++ b/biomes/rainforest/capuchin-monkey.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(20, 60, 40, 0.9), rgba(10, 30, 20, 0.75)),
-        url('https://images.unsplash.com/photo-1535930749574-1399327ce78f?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/rainforest.svg') center/cover;"
     >
       <h1>Capuchin Monkey</h1>
       <p class="hero-text">Curious climbers</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Rainforest Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1535930749574-1399327ce78f?auto=format&fit=crop&w=1200&q=80"
-          alt="Capuchin monkey looking at the camera"
+          src="../../assets/img/animals/rainforest/capuchin-monkey.svg"
+          alt="Capuchin Monkey illustration"
         />
         <div class="intro">
           <span class="biome-badge">Rainforest</span>

--- a/biomes/rainforest/green-anaconda.html
+++ b/biomes/rainforest/green-anaconda.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(20, 60, 40, 0.9), rgba(10, 30, 20, 0.75)),
-        url('https://images.unsplash.com/photo-1543248939-ff40856f65d4?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/rainforest.svg') center/cover;"
     >
       <h1>Green Anaconda</h1>
       <p class="hero-text">River powerhouse</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Rainforest Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1543248939-ff40856f65d4?auto=format&fit=crop&w=1200&q=80"
-          alt="Green anaconda coiled in water"
+          src="../../assets/img/animals/rainforest/green-anaconda.svg"
+          alt="Green Anaconda illustration"
         />
         <div class="intro">
           <span class="biome-badge">Rainforest</span>

--- a/biomes/rainforest/harpy-eagle.html
+++ b/biomes/rainforest/harpy-eagle.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(20, 60, 40, 0.9), rgba(10, 30, 20, 0.75)),
-        url('https://images.unsplash.com/photo-1578321272115-ef09c01081ea?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/rainforest.svg') center/cover;"
     >
       <h1>Harpy Eagle</h1>
       <p class="hero-text">Sky king of the canopy</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Rainforest Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1578321272115-ef09c01081ea?auto=format&fit=crop&w=1200&q=80"
-          alt="Harpy eagle perched on a branch"
+          src="../../assets/img/animals/rainforest/harpy-eagle.svg"
+          alt="Harpy Eagle illustration"
         />
         <div class="intro">
           <span class="biome-badge">Rainforest</span>

--- a/biomes/rainforest/index.html
+++ b/biomes/rainforest/index.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(19, 76, 61, 0.9), rgba(19, 43, 33, 0.75)),
-        url('https://images.unsplash.com/photo-1513836279014-a89f7a76ae86?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/rainforest.svg') center/cover;"
     >
       <h1>Rainforest Animals</h1>
       <p class="hero-text">
@@ -26,73 +26,109 @@
     <main class="container">
       <a class="back-link" href="../../index.html">← Back to Biome Adventure</a>
       <div class="animal-grid">
-        <a class="card" href="jaguar.html" style="background: url('https://images.unsplash.com/photo-1546182990-dffeafbe841d?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="jaguar.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/rainforest/jaguar.svg" alt="Jaguar illustration" />
+          </div>
           <div class="card-content">
             <h3>Jaguar</h3>
             <p>Powerful hunter with spotted camouflage.</p>
           </div>
         </a>
-        <a class="card" href="poison-dart-frog.html" style="background: url('https://images.unsplash.com/photo-1544027993-37dbfe43562a?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="poison-dart-frog.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/rainforest/poison-dart-frog.svg" alt="Poison Dart Frog illustration" />
+          </div>
           <div class="card-content">
             <h3>Poison Dart Frog</h3>
             <p>Small but brightly colored with big warnings.</p>
           </div>
         </a>
-        <a class="card" href="sloth.html" style="background: url('https://images.unsplash.com/photo-1466629437334-827c604b3bd4?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="sloth.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/rainforest/sloth.svg" alt="Sloth illustration" />
+          </div>
           <div class="card-content">
             <h3>Sloth</h3>
             <p>Slow climber with cozy tree homes.</p>
           </div>
         </a>
-        <a class="card" href="toucan.html" style="background: url('https://images.unsplash.com/photo-1531884070720-875c7622d4dd?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="toucan.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/rainforest/toucan.svg" alt="Toucan illustration" />
+          </div>
           <div class="card-content">
             <h3>Toucan</h3>
             <p>Rainbow beaks for reaching juicy fruit.</p>
           </div>
         </a>
-        <a class="card" href="capuchin-monkey.html" style="background: url('https://images.unsplash.com/photo-1535930749574-1399327ce78f?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="capuchin-monkey.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/rainforest/capuchin-monkey.svg" alt="Capuchin Monkey illustration" />
+          </div>
           <div class="card-content">
             <h3>Capuchin Monkey</h3>
             <p>Clever climbers with curious hands.</p>
           </div>
         </a>
-        <a class="card" href="leafcutter-ant.html" style="background: url('https://images.unsplash.com/photo-1562163475-48e98b143de0?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="leafcutter-ant.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/rainforest/leafcutter-ant.svg" alt="Leafcutter Ant illustration" />
+          </div>
           <div class="card-content">
             <h3>Leafcutter Ant</h3>
             <p>Teamwork superstars who garden underground.</p>
           </div>
         </a>
-        <a class="card" href="harpy-eagle.html" style="background: url('https://images.unsplash.com/photo-1578321272115-ef09c01081ea?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="harpy-eagle.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/rainforest/harpy-eagle.svg" alt="Harpy Eagle illustration" />
+          </div>
           <div class="card-content">
             <h3>Harpy Eagle</h3>
             <p>Giant wings soaring through the canopy.</p>
           </div>
         </a>
-        <a class="card" href="green-anaconda.html" style="background: url('https://images.unsplash.com/photo-1543248939-ff40856f65d4?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="green-anaconda.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/rainforest/green-anaconda.svg" alt="Green Anaconda illustration" />
+          </div>
           <div class="card-content">
             <h3>Green Anaconda</h3>
             <p>Heavy swimmer who hugs tightly.</p>
           </div>
         </a>
-        <a class="card" href="orangutan.html" style="background: url('https://images.unsplash.com/photo-1587222535671-1cc8769f8df4?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="orangutan.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/rainforest/orangutan.svg" alt="Orangutan illustration" />
+          </div>
           <div class="card-content">
             <h3>Orangutan</h3>
             <p>Gentle giants swinging with long arms.</p>
           </div>
         </a>
-        <a class="card" href="leaf-tailed-gecko.html" style="background: url('https://images.unsplash.com/photo-1584273143981-5caa64d9984a?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="leaf-tailed-gecko.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/rainforest/leaf-tailed-gecko.svg" alt="Leaf-Tailed Gecko illustration" />
+          </div>
           <div class="card-content">
             <h3>Leaf-Tailed Gecko</h3>
             <p>Disappears against bark with leafy tails.</p>
           </div>
         </a>
-        <a class="card" href="amazon-river-dolphin.html" style="background: url('https://images.unsplash.com/photo-1544552866-31fa0f0c7c79?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="amazon-river-dolphin.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/rainforest/amazon-river-dolphin.svg" alt="Amazon River Dolphin illustration" />
+          </div>
           <div class="card-content">
             <h3>Amazon River Dolphin</h3>
             <p>Blushing pink swimmers in muddy rivers.</p>
           </div>
         </a>
-        <a class="card" href="scarlet-macaw.html" style="background: url('https://images.unsplash.com/photo-1583511655857-d19b40a7a54e?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="scarlet-macaw.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/rainforest/scarlet-macaw.svg" alt="Scarlet Macaw illustration" />
+          </div>
           <div class="card-content">
             <h3>Scarlet Macaw</h3>
             <p>Bright parrots with powerful beaks.</p>

--- a/biomes/rainforest/jaguar.html
+++ b/biomes/rainforest/jaguar.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(20, 60, 40, 0.9), rgba(10, 30, 20, 0.75)),
-        url('https://images.unsplash.com/photo-1546182990-dffeafbe841d?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/rainforest.svg') center/cover;"
     >
       <h1>Jaguar</h1>
       <p class="hero-text">Rainforest stealth master</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Rainforest Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1546182990-dffeafbe841d?auto=format&fit=crop&w=1200&q=80"
-          alt="Jaguar resting on a branch"
+          src="../../assets/img/animals/rainforest/jaguar.svg"
+          alt="Jaguar illustration"
         />
         <div class="intro">
           <span class="biome-badge">Rainforest</span>

--- a/biomes/rainforest/leaf-tailed-gecko.html
+++ b/biomes/rainforest/leaf-tailed-gecko.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(20, 60, 40, 0.9), rgba(10, 30, 20, 0.75)),
-        url('https://images.unsplash.com/photo-1584273143981-5caa64d9984a?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/rainforest.svg') center/cover;"
     >
       <h1>Leaf-Tailed Gecko</h1>
       <p class="hero-text">Camouflage champion</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Rainforest Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1584273143981-5caa64d9984a?auto=format&fit=crop&w=1200&q=80"
-          alt="Leaf-tailed gecko blending into bark"
+          src="../../assets/img/animals/rainforest/leaf-tailed-gecko.svg"
+          alt="Leaf-Tailed Gecko illustration"
         />
         <div class="intro">
           <span class="biome-badge">Rainforest</span>

--- a/biomes/rainforest/leafcutter-ant.html
+++ b/biomes/rainforest/leafcutter-ant.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(20, 60, 40, 0.9), rgba(10, 30, 20, 0.75)),
-        url('https://images.unsplash.com/photo-1562163475-48e98b143de0?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/rainforest.svg') center/cover;"
     >
       <h1>Leafcutter Ant</h1>
       <p class="hero-text">Tiny farmers of the forest</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Rainforest Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1562163475-48e98b143de0?auto=format&fit=crop&w=1200&q=80"
-          alt="Leafcutter ant carrying a leaf"
+          src="../../assets/img/animals/rainforest/leafcutter-ant.svg"
+          alt="Leafcutter Ant illustration"
         />
         <div class="intro">
           <span class="biome-badge">Rainforest</span>

--- a/biomes/rainforest/orangutan.html
+++ b/biomes/rainforest/orangutan.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(20, 60, 40, 0.9), rgba(10, 30, 20, 0.75)),
-        url('https://images.unsplash.com/photo-1587222535671-1cc8769f8df4?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/rainforest.svg') center/cover;"
     >
       <h1>Orangutan</h1>
       <p class="hero-text">Gentle forest giant</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Rainforest Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1587222535671-1cc8769f8df4?auto=format&fit=crop&w=1200&q=80"
-          alt="Orangutan hanging from a vine"
+          src="../../assets/img/animals/rainforest/orangutan.svg"
+          alt="Orangutan illustration"
         />
         <div class="intro">
           <span class="biome-badge">Rainforest</span>

--- a/biomes/rainforest/poison-dart-frog.html
+++ b/biomes/rainforest/poison-dart-frog.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(20, 60, 40, 0.9), rgba(10, 30, 20, 0.75)),
-        url('https://images.unsplash.com/photo-1544027993-37dbfe43562a?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/rainforest.svg') center/cover;"
     >
       <h1>Poison Dart Frog</h1>
       <p class="hero-text">Bright colors with a bold message</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Rainforest Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1544027993-37dbfe43562a?auto=format&fit=crop&w=1200&q=80"
-          alt="Yellow poison dart frog on a leaf"
+          src="../../assets/img/animals/rainforest/poison-dart-frog.svg"
+          alt="Poison Dart Frog illustration"
         />
         <div class="intro">
           <span class="biome-badge">Rainforest</span>

--- a/biomes/rainforest/scarlet-macaw.html
+++ b/biomes/rainforest/scarlet-macaw.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(20, 60, 40, 0.9), rgba(10, 30, 20, 0.75)),
-        url('https://images.unsplash.com/photo-1583511655857-d19b40a7a54e?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/rainforest.svg') center/cover;"
     >
       <h1>Scarlet Macaw</h1>
       <p class="hero-text">Feathered rainbow</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Rainforest Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1583511655857-d19b40a7a54e?auto=format&fit=crop&w=1200&q=80"
-          alt="Scarlet macaw spreading its wings"
+          src="../../assets/img/animals/rainforest/scarlet-macaw.svg"
+          alt="Scarlet Macaw illustration"
         />
         <div class="intro">
           <span class="biome-badge">Rainforest</span>

--- a/biomes/rainforest/sloth.html
+++ b/biomes/rainforest/sloth.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(20, 60, 40, 0.9), rgba(10, 30, 20, 0.75)),
-        url('https://images.unsplash.com/photo-1466629437334-827c604b3bd4?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/rainforest.svg') center/cover;"
     >
       <h1>Sloth</h1>
       <p class="hero-text">Slow and steady tree friend</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Rainforest Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1466629437334-827c604b3bd4?auto=format&fit=crop&w=1200&q=80"
-          alt="Brown-throated sloth hanging on a branch"
+          src="../../assets/img/animals/rainforest/sloth.svg"
+          alt="Sloth illustration"
         />
         <div class="intro">
           <span class="biome-badge">Rainforest</span>

--- a/biomes/rainforest/toucan.html
+++ b/biomes/rainforest/toucan.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(20, 60, 40, 0.9), rgba(10, 30, 20, 0.75)),
-        url('https://images.unsplash.com/photo-1531884070720-875c7622d4dd?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/rainforest.svg') center/cover;"
     >
       <h1>Toucan</h1>
       <p class="hero-text">Rainbow-billed fruit lover</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Rainforest Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1531884070720-875c7622d4dd?auto=format&fit=crop&w=1200&q=80"
-          alt="Toucan sitting on a branch"
+          src="../../assets/img/animals/rainforest/toucan.svg"
+          alt="Toucan illustration"
         />
         <div class="intro">
           <span class="biome-badge">Rainforest</span>

--- a/biomes/savannah/african-elephant.html
+++ b/biomes/savannah/african-elephant.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(167, 98, 12, 0.9), rgba(96, 59, 9, 0.75)),
-        url('https://images.unsplash.com/photo-1508672019048-805c876b67e2?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/savannah.svg') center/cover;"
     >
       <h1>African Elephant</h1>
       <p class="hero-text">Gentle giants of the grass</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Savannah Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1508672019048-805c876b67e2?auto=format&fit=crop&w=1200&q=80"
-          alt="African elephant walking across the savannah"
+          src="../../assets/img/animals/savannah/african-elephant.svg"
+          alt="African Elephant illustration"
         />
         <div class="intro">
           <span class="biome-badge">Savannah</span>

--- a/biomes/savannah/african-wild-dog.html
+++ b/biomes/savannah/african-wild-dog.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(167, 98, 12, 0.9), rgba(96, 59, 9, 0.75)),
-        url('https://images.unsplash.com/photo-1516280440614-37939bbacd81?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/savannah.svg') center/cover;"
     >
       <h1>African Wild Dog</h1>
       <p class="hero-text">Painted pack partners</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Savannah Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1516280440614-37939bbacd81?auto=format&fit=crop&w=1200&q=80"
-          alt="African wild dogs standing together"
+          src="../../assets/img/animals/savannah/african-wild-dog.svg"
+          alt="African Wild Dog illustration"
         />
         <div class="intro">
           <span class="biome-badge">Savannah</span>

--- a/biomes/savannah/cheetah.html
+++ b/biomes/savannah/cheetah.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(167, 98, 12, 0.9), rgba(96, 59, 9, 0.75)),
-        url('https://images.unsplash.com/photo-1510414842594-a61c69b5ae57?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/savannah.svg') center/cover;"
     >
       <h1>Cheetah</h1>
       <p class="hero-text">Fastest feet on land</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Savannah Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1510414842594-a61c69b5ae57?auto=format&fit=crop&w=1200&q=80"
-          alt="Cheetah standing in grass"
+          src="../../assets/img/animals/savannah/cheetah.svg"
+          alt="Cheetah illustration"
         />
         <div class="intro">
           <span class="biome-badge">Savannah</span>

--- a/biomes/savannah/giraffe.html
+++ b/biomes/savannah/giraffe.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(167, 98, 12, 0.9), rgba(96, 59, 9, 0.75)),
-        url('https://images.unsplash.com/photo-1529257414771-1960a1b9e20b?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/savannah.svg') center/cover;"
     >
       <h1>Giraffe</h1>
       <p class="hero-text">Tall tree-top nibblers</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Savannah Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1529257414771-1960a1b9e20b?auto=format&fit=crop&w=1200&q=80"
-          alt="Giraffe reaching for leaves"
+          src="../../assets/img/animals/savannah/giraffe.svg"
+          alt="Giraffe illustration"
         />
         <div class="intro">
           <span class="biome-badge">Savannah</span>

--- a/biomes/savannah/hippopotamus.html
+++ b/biomes/savannah/hippopotamus.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(167, 98, 12, 0.9), rgba(96, 59, 9, 0.75)),
-        url('https://images.unsplash.com/photo-1508672019048-805c876b67e2?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/savannah.svg') center/cover;"
     >
       <h1>Hippopotamus</h1>
       <p class="hero-text">Riverbank heavyweight</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Savannah Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1508672019048-805c876b67e2?auto=format&fit=crop&w=1200&q=80"
-          alt="Hippo opening its mouth in water"
+          src="../../assets/img/animals/savannah/hippopotamus.svg"
+          alt="Hippopotamus illustration"
         />
         <div class="intro">
           <span class="biome-badge">Savannah</span>

--- a/biomes/savannah/index.html
+++ b/biomes/savannah/index.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(167, 98, 12, 0.9), rgba(96, 59, 9, 0.75)),
-        url('https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/savannah.svg') center/cover;"
     >
       <h1>Savannah Animals</h1>
       <p class="hero-text">
@@ -25,73 +25,109 @@
     <main class="container">
       <a class="back-link" href="../../index.html">← Back to Biome Adventure</a>
       <div class="animal-grid">
-        <a class="card" href="african-elephant.html" style="background: url('https://images.unsplash.com/photo-1508672019048-805c876b67e2?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="african-elephant.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/savannah/african-elephant.svg" alt="African Elephant illustration" />
+          </div>
           <div class="card-content">
             <h3>African Elephant</h3>
             <p>Gentle giants with helpful trunks.</p>
           </div>
         </a>
-        <a class="card" href="lion.html" style="background: url('https://images.unsplash.com/photo-1546182990-dffeafbe841d?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="lion.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/savannah/lion.svg" alt="Lion illustration" />
+          </div>
           <div class="card-content">
             <h3>Lion</h3>
             <p>Cooperative cats known as the pride.</p>
           </div>
         </a>
-        <a class="card" href="cheetah.html" style="background: url('https://images.unsplash.com/photo-1510414842594-a61c69b5ae57?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="cheetah.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/savannah/cheetah.svg" alt="Cheetah illustration" />
+          </div>
           <div class="card-content">
             <h3>Cheetah</h3>
             <p>The fastest sprinters on four paws.</p>
           </div>
         </a>
-        <a class="card" href="giraffe.html" style="background: url('https://images.unsplash.com/photo-1529257414771-1960a1b9e20b?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="giraffe.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/savannah/giraffe.svg" alt="Giraffe illustration" />
+          </div>
           <div class="card-content">
             <h3>Giraffe</h3>
             <p>Sky-high snackers with long tongues.</p>
           </div>
         </a>
-        <a class="card" href="zebra.html" style="background: url('https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="zebra.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/savannah/zebra.svg" alt="Zebra illustration" />
+          </div>
           <div class="card-content">
             <h3>Zebra</h3>
             <p>Striped friends who confuse predators.</p>
           </div>
         </a>
-        <a class="card" href="meerkat.html" style="background: url('https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="meerkat.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/savannah/meerkat.svg" alt="Meerkat illustration" />
+          </div>
           <div class="card-content">
             <h3>Meerkat</h3>
             <p>Tiny lookouts with loud warnings.</p>
           </div>
         </a>
-        <a class="card" href="wildebeest.html" style="background: url('https://images.unsplash.com/photo-1498503403619-06dc03466e90?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="wildebeest.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/savannah/wildebeest.svg" alt="Wildebeest illustration" />
+          </div>
           <div class="card-content">
             <h3>Wildebeest</h3>
             <p>Long-distance runners of the plains.</p>
           </div>
         </a>
-        <a class="card" href="secretary-bird.html" style="background: url('https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="secretary-bird.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/savannah/secretary-bird.svg" alt="Secretary Bird illustration" />
+          </div>
           <div class="card-content">
             <h3>Secretary Bird</h3>
             <p>Tall birds that stomp sneaky snakes.</p>
           </div>
         </a>
-        <a class="card" href="african-wild-dog.html" style="background: url('https://images.unsplash.com/photo-1516280440614-37939bbacd81?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="african-wild-dog.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/savannah/african-wild-dog.svg" alt="African Wild Dog illustration" />
+          </div>
           <div class="card-content">
             <h3>African Wild Dog</h3>
             <p>Painted runners who share their food.</p>
           </div>
         </a>
-        <a class="card" href="hippopotamus.html" style="background: url('https://images.unsplash.com/photo-1508672019048-805c876b67e2?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="hippopotamus.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/savannah/hippopotamus.svg" alt="Hippopotamus illustration" />
+          </div>
           <div class="card-content">
             <h3>Hippopotamus</h3>
             <p>Mighty mouths that love the water.</p>
           </div>
         </a>
-        <a class="card" href="ostrich.html" style="background: url('https://images.unsplash.com/photo-1526318896980-cf78c088247c?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="ostrich.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/savannah/ostrich.svg" alt="Ostrich illustration" />
+          </div>
           <div class="card-content">
             <h3>Ostrich</h3>
             <p>Feathered runners with huge eggs.</p>
           </div>
         </a>
-        <a class="card" href="warthog.html" style="background: url('https://images.unsplash.com/photo-1508672019048-805c876b67e2?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="warthog.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/savannah/warthog.svg" alt="Warthog illustration" />
+          </div>
           <div class="card-content">
             <h3>Warthog</h3>
             <p>Tough pigs with protective tusks.</p>

--- a/biomes/savannah/lion.html
+++ b/biomes/savannah/lion.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(167, 98, 12, 0.9), rgba(96, 59, 9, 0.75)),
-        url('https://images.unsplash.com/photo-1546182990-dffeafbe841d?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/savannah.svg') center/cover;"
     >
       <h1>Lion</h1>
       <p class="hero-text">Teamwork makes the pride</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Savannah Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1508672019048-805c876b67e2?auto=format&fit=crop&w=1200&q=80"
-          alt="Lioness walking in tall grass"
+          src="../../assets/img/animals/savannah/lion.svg"
+          alt="Lion illustration"
         />
         <div class="intro">
           <span class="biome-badge">Savannah</span>

--- a/biomes/savannah/meerkat.html
+++ b/biomes/savannah/meerkat.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(167, 98, 12, 0.9), rgba(96, 59, 9, 0.75)),
-        url('https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/savannah.svg') center/cover;"
     >
       <h1>Meerkat</h1>
       <p class="hero-text">Watchful diggers</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Savannah Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80"
-          alt="Meerkat standing on lookout"
+          src="../../assets/img/animals/savannah/meerkat.svg"
+          alt="Meerkat illustration"
         />
         <div class="intro">
           <span class="biome-badge">Savannah</span>

--- a/biomes/savannah/ostrich.html
+++ b/biomes/savannah/ostrich.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(167, 98, 12, 0.9), rgba(96, 59, 9, 0.75)),
-        url('https://images.unsplash.com/photo-1526318896980-cf78c088247c?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/savannah.svg') center/cover;"
     >
       <h1>Ostrich</h1>
       <p class="hero-text">Biggest bird on Earth</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Savannah Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1526318896980-cf78c088247c?auto=format&fit=crop&w=1200&q=80"
-          alt="Ostrich running"
+          src="../../assets/img/animals/savannah/ostrich.svg"
+          alt="Ostrich illustration"
         />
         <div class="intro">
           <span class="biome-badge">Savannah</span>

--- a/biomes/savannah/secretary-bird.html
+++ b/biomes/savannah/secretary-bird.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(167, 98, 12, 0.9), rgba(96, 59, 9, 0.75)),
-        url('https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/savannah.svg') center/cover;"
     >
       <h1>Secretary Bird</h1>
       <p class="hero-text">Elegant snake stomper</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Savannah Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1526318896980-cf78c088247c?auto=format&fit=crop&w=1200&q=80"
-          alt="Secretary bird walking in the savannah"
+          src="../../assets/img/animals/savannah/secretary-bird.svg"
+          alt="Secretary Bird illustration"
         />
         <div class="intro">
           <span class="biome-badge">Savannah</span>

--- a/biomes/savannah/warthog.html
+++ b/biomes/savannah/warthog.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(167, 98, 12, 0.9), rgba(96, 59, 9, 0.75)),
-        url('https://images.unsplash.com/photo-1508672019048-805c876b67e2?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/savannah.svg') center/cover;"
     >
       <h1>Warthog</h1>
       <p class="hero-text">Tough grassland digger</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Savannah Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1508672019048-805c876b67e2?auto=format&fit=crop&w=1200&q=80"
-          alt="Warthog standing in grass"
+          src="../../assets/img/animals/savannah/warthog.svg"
+          alt="Warthog illustration"
         />
         <div class="intro">
           <span class="biome-badge">Savannah</span>

--- a/biomes/savannah/wildebeest.html
+++ b/biomes/savannah/wildebeest.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(167, 98, 12, 0.9), rgba(96, 59, 9, 0.75)),
-        url('https://images.unsplash.com/photo-1498503403619-06dc03466e90?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/savannah.svg') center/cover;"
     >
       <h1>Wildebeest</h1>
       <p class="hero-text">Migrating champions</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Savannah Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1498503403619-06dc03466e90?auto=format&fit=crop&w=1200&q=80"
-          alt="Herd of wildebeest running"
+          src="../../assets/img/animals/savannah/wildebeest.svg"
+          alt="Wildebeest illustration"
         />
         <div class="intro">
           <span class="biome-badge">Savannah</span>

--- a/biomes/savannah/zebra.html
+++ b/biomes/savannah/zebra.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(167, 98, 12, 0.9), rgba(96, 59, 9, 0.75)),
-        url('https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/savannah.svg') center/cover;"
     >
       <h1>Zebra</h1>
       <p class="hero-text">Striped savannah traveler</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Savannah Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1200&q=80"
-          alt="Zebras standing together"
+          src="../../assets/img/animals/savannah/zebra.svg"
+          alt="Zebra illustration"
         />
         <div class="intro">
           <span class="biome-badge">Savannah</span>

--- a/biomes/tundra/arctic-fox.html
+++ b/biomes/tundra/arctic-fox.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(66, 108, 163, 0.92), rgba(17, 34, 63, 0.75)),
-        url('https://images.unsplash.com/photo-1456926631375-92c8ce872def?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/tundra.svg') center/cover;"
     >
       <h1>Arctic Fox</h1>
       <p class="hero-text">Frosty furball</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Tundra Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1456926631375-92c8ce872def?auto=format&fit=crop&w=1200&q=80"
-          alt="Arctic fox in snowy landscape"
+          src="../../assets/img/animals/tundra/arctic-fox.svg"
+          alt="Arctic Fox illustration"
         />
         <div class="intro">
           <span class="biome-badge">Tundra</span>

--- a/biomes/tundra/arctic-hare.html
+++ b/biomes/tundra/arctic-hare.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(66, 108, 163, 0.92), rgba(17, 34, 63, 0.75)),
-        url('https://images.unsplash.com/photo-1526336024174-e58f5cdd8e13?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/tundra.svg') center/cover;"
     >
       <h1>Arctic Hare</h1>
       <p class="hero-text">Snow sprinter</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Tundra Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1526336024174-e58f5cdd8e13?auto=format&fit=crop&w=1200&q=80"
-          alt="Arctic hare in white winter fur"
+          src="../../assets/img/animals/tundra/arctic-hare.svg"
+          alt="Arctic Hare illustration"
         />
         <div class="intro">
           <span class="biome-badge">Tundra</span>

--- a/biomes/tundra/arctic-wolf.html
+++ b/biomes/tundra/arctic-wolf.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(66, 108, 163, 0.92), rgba(17, 34, 63, 0.75)),
-        url('https://images.unsplash.com/photo-1495231916356-a86217efff12?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/tundra.svg') center/cover;"
     >
       <h1>Arctic Wolf</h1>
       <p class="hero-text">Snowy pack hunter</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Tundra Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1495231916356-a86217efff12?auto=format&fit=crop&w=1200&q=80"
-          alt="Arctic wolf standing in snow"
+          src="../../assets/img/animals/tundra/arctic-wolf.svg"
+          alt="Arctic Wolf illustration"
         />
         <div class="intro">
           <span class="biome-badge">Tundra</span>

--- a/biomes/tundra/atlantic-puffin.html
+++ b/biomes/tundra/atlantic-puffin.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(66, 108, 163, 0.92), rgba(17, 34, 63, 0.75)),
-        url('https://images.unsplash.com/photo-1504609773096-104ff2c73ba4?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/tundra.svg') center/cover;"
     >
       <h1>Atlantic Puffin</h1>
       <p class="hero-text">Colorful cliff diver</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Tundra Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1504609773096-104ff2c73ba4?auto=format&fit=crop&w=1200&q=80"
-          alt="Atlantic puffin holding fish"
+          src="../../assets/img/animals/tundra/atlantic-puffin.svg"
+          alt="Atlantic Puffin illustration"
         />
         <div class="intro">
           <span class="biome-badge">Tundra</span>

--- a/biomes/tundra/caribou.html
+++ b/biomes/tundra/caribou.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(66, 108, 163, 0.92), rgba(17, 34, 63, 0.75)),
-        url('https://images.unsplash.com/photo-1496568816309-51d7c20e79b1?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/tundra.svg') center/cover;"
     >
       <h1>Caribou</h1>
       <p class="hero-text">Traveling reindeer</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Tundra Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1496568816309-51d7c20e79b1?auto=format&fit=crop&w=1200&q=80"
-          alt="Caribou walking in tundra"
+          src="../../assets/img/animals/tundra/caribou.svg"
+          alt="Caribou illustration"
         />
         <div class="intro">
           <span class="biome-badge">Tundra</span>

--- a/biomes/tundra/index.html
+++ b/biomes/tundra/index.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(66, 108, 163, 0.92), rgba(17, 34, 63, 0.75)),
-        url('https://images.unsplash.com/photo-1476610182048-b716b8518aae?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/tundra.svg') center/cover;"
     >
       <h1>Tundra Animals</h1>
       <p class="hero-text">
@@ -26,73 +26,109 @@
     <main class="container">
       <a class="back-link" href="../../index.html">← Back to Biome Adventure</a>
       <div class="animal-grid">
-        <a class="card" href="arctic-fox.html" style="background: url('https://images.unsplash.com/photo-1456926631375-92c8ce872def?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="arctic-fox.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/tundra/arctic-fox.svg" alt="Arctic Fox illustration" />
+          </div>
           <div class="card-content">
             <h3>Arctic Fox</h3>
             <p>Fluffy coats that change with the seasons.</p>
           </div>
         </a>
-        <a class="card" href="polar-bear.html" style="background: url('https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="polar-bear.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/tundra/polar-bear.svg" alt="Polar Bear illustration" />
+          </div>
           <div class="card-content">
             <h3>Polar Bear</h3>
             <p>Ice walkers with paws made for snow.</p>
           </div>
         </a>
-        <a class="card" href="snowy-owl.html" style="background: url('https://images.unsplash.com/photo-1501706362039-c6e08e3f9c03?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="snowy-owl.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/tundra/snowy-owl.svg" alt="Snowy Owl illustration" />
+          </div>
           <div class="card-content">
             <h3>Snowy Owl</h3>
             <p>Silent flyers with bright yellow eyes.</p>
           </div>
         </a>
-        <a class="card" href="caribou.html" style="background: url('https://images.unsplash.com/photo-1496568816309-51d7c20e79b1?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="caribou.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/tundra/caribou.svg" alt="Caribou illustration" />
+          </div>
           <div class="card-content">
             <h3>Caribou</h3>
             <p>Migrating reindeer with wide hooves.</p>
           </div>
         </a>
-        <a class="card" href="musk-ox.html" style="background: url('https://images.unsplash.com/photo-1476610182048-b716b8518aae?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="musk-ox.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/tundra/musk-ox.svg" alt="Musk Ox illustration" />
+          </div>
           <div class="card-content">
             <h3>Musk Ox</h3>
             <p>Wooly shields against the wind.</p>
           </div>
         </a>
-        <a class="card" href="arctic-hare.html" style="background: url('https://images.unsplash.com/photo-1526336024174-e58f5cdd8e13?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="arctic-hare.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/tundra/arctic-hare.svg" alt="Arctic Hare illustration" />
+          </div>
           <div class="card-content">
             <h3>Arctic Hare</h3>
             <p>Snow sprinters with furry paws.</p>
           </div>
         </a>
-        <a class="card" href="lemming.html" style="background: url('https://images.unsplash.com/photo-1528150177500-0e5f464b26e3?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="lemming.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/tundra/lemming.svg" alt="Lemming illustration" />
+          </div>
           <div class="card-content">
             <h3>Lemming</h3>
             <p>Burrow builders who stay busy.</p>
           </div>
         </a>
-        <a class="card" href="walrus.html" style="background: url('https://images.unsplash.com/photo-1441974231531-c6227db76b6e?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="walrus.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/tundra/walrus.svg" alt="Walrus illustration" />
+          </div>
           <div class="card-content">
             <h3>Walrus</h3>
             <p>Tusked giants that rest on ice.</p>
           </div>
         </a>
-        <a class="card" href="narwhal.html" style="background: url('https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="narwhal.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/tundra/narwhal.svg" alt="Narwhal illustration" />
+          </div>
           <div class="card-content">
             <h3>Narwhal</h3>
             <p>Unicorn whales with sensitive tusks.</p>
           </div>
         </a>
-        <a class="card" href="arctic-wolf.html" style="background: url('https://images.unsplash.com/photo-1495231916356-a86217efff12?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="arctic-wolf.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/tundra/arctic-wolf.svg" alt="Arctic Wolf illustration" />
+          </div>
           <div class="card-content">
             <h3>Arctic Wolf</h3>
             <p>Packs of snowy hunters who share.</p>
           </div>
         </a>
-        <a class="card" href="atlantic-puffin.html" style="background: url('https://images.unsplash.com/photo-1504609773096-104ff2c73ba4?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="atlantic-puffin.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/tundra/atlantic-puffin.svg" alt="Atlantic Puffin illustration" />
+          </div>
           <div class="card-content">
             <h3>Atlantic Puffin</h3>
             <p>Colorful beaks perfect for fish.</p>
           </div>
         </a>
-        <a class="card" href="ringed-seal.html" style="background: url('https://images.unsplash.com/photo-1476610182048-b716b8518aae?auto=format&fit=crop&w=900&q=80') center/cover;">
+        <a class="card" href="ringed-seal.html">
+          <div class="card-image">
+            <img src="../../assets/img/animals/tundra/ringed-seal.svg" alt="Ringed Seal illustration" />
+          </div>
           <div class="card-content">
             <h3>Ringed Seal</h3>
             <p>Ice den experts with whiskery faces.</p>

--- a/biomes/tundra/lemming.html
+++ b/biomes/tundra/lemming.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(66, 108, 163, 0.92), rgba(17, 34, 63, 0.75)),
-        url('https://images.unsplash.com/photo-1528150177500-0e5f464b26e3?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/tundra.svg') center/cover;"
     >
       <h1>Lemming</h1>
       <p class="hero-text">Busy tundra nibblers</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Tundra Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1528150177500-0e5f464b26e3?auto=format&fit=crop&w=1200&q=80"
-          alt="Lemming standing on moss"
+          src="../../assets/img/animals/tundra/lemming.svg"
+          alt="Lemming illustration"
         />
         <div class="intro">
           <span class="biome-badge">Tundra</span>

--- a/biomes/tundra/musk-ox.html
+++ b/biomes/tundra/musk-ox.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(66, 108, 163, 0.92), rgba(17, 34, 63, 0.75)),
-        url('https://images.unsplash.com/photo-1476610182048-b716b8518aae?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/tundra.svg') center/cover;"
     >
       <h1>Musk Ox</h1>
       <p class="hero-text">Wooly wall</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Tundra Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1476610182048-b716b8518aae?auto=format&fit=crop&w=1200&q=80"
-          alt="Musk ox standing in snow"
+          src="../../assets/img/animals/tundra/musk-ox.svg"
+          alt="Musk Ox illustration"
         />
         <div class="intro">
           <span class="biome-badge">Tundra</span>

--- a/biomes/tundra/narwhal.html
+++ b/biomes/tundra/narwhal.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(66, 108, 163, 0.92), rgba(17, 34, 63, 0.75)),
-        url('https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/tundra.svg') center/cover;"
     >
       <h1>Narwhal</h1>
       <p class="hero-text">Unicorn of the sea</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Tundra Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?auto=format&fit=crop&w=1200&q=80"
-          alt="Narwhal swimming in icy sea"
+          src="../../assets/img/animals/tundra/narwhal.svg"
+          alt="Narwhal illustration"
         />
         <div class="intro">
           <span class="biome-badge">Tundra</span>

--- a/biomes/tundra/polar-bear.html
+++ b/biomes/tundra/polar-bear.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(66, 108, 163, 0.92), rgba(17, 34, 63, 0.75)),
-        url('https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/tundra.svg') center/cover;"
     >
       <h1>Polar Bear</h1>
       <p class="hero-text">Great white hunter</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Tundra Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=1200&q=80"
-          alt="Polar bear walking on snow"
+          src="../../assets/img/animals/tundra/polar-bear.svg"
+          alt="Polar Bear illustration"
         />
         <div class="intro">
           <span class="biome-badge">Tundra</span>

--- a/biomes/tundra/ringed-seal.html
+++ b/biomes/tundra/ringed-seal.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(66, 108, 163, 0.92), rgba(17, 34, 63, 0.75)),
-        url('https://images.unsplash.com/photo-1476610182048-b716b8518aae?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/tundra.svg') center/cover;"
     >
       <h1>Ringed Seal</h1>
       <p class="hero-text">Ice den expert</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Tundra Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1476610182048-b716b8518aae?auto=format&fit=crop&w=1200&q=80"
-          alt="Ringed seal resting on ice"
+          src="../../assets/img/animals/tundra/ringed-seal.svg"
+          alt="Ringed Seal illustration"
         />
         <div class="intro">
           <span class="biome-badge">Tundra</span>

--- a/biomes/tundra/snowy-owl.html
+++ b/biomes/tundra/snowy-owl.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(66, 108, 163, 0.92), rgba(17, 34, 63, 0.75)),
-        url('https://images.unsplash.com/photo-1501706362039-c6e08e3f9c03?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/tundra.svg') center/cover;"
     >
       <h1>Snowy Owl</h1>
       <p class="hero-text">Silent snow hunter</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Tundra Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1501706362039-c6e08e3f9c03?auto=format&fit=crop&w=1200&q=80"
-          alt="Snowy owl perched on snow"
+          src="../../assets/img/animals/tundra/snowy-owl.svg"
+          alt="Snowy Owl illustration"
         />
         <div class="intro">
           <span class="biome-badge">Tundra</span>

--- a/biomes/tundra/walrus.html
+++ b/biomes/tundra/walrus.html
@@ -15,7 +15,7 @@
   <body>
     <header
       style="background: linear-gradient(135deg, rgba(66, 108, 163, 0.92), rgba(17, 34, 63, 0.75)),
-        url('https://images.unsplash.com/photo-1441974231531-c6227db76b6e?auto=format&fit=crop&w=1600&q=80') center/cover;"
+        url('../../assets/img/biomes/tundra.svg') center/cover;"
     >
       <h1>Walrus</h1>
       <p class="hero-text">Tusked ocean giant</p>
@@ -24,8 +24,8 @@
       <a class="back-link" href="index.html">← Back to Tundra Animals</a>
       <div class="animal-hero">
         <img
-          src="https://images.unsplash.com/photo-1441974231531-c6227db76b6e?auto=format&fit=crop&w=1200&q=80"
-          alt="Walrus resting on ice"
+          src="../../assets/img/animals/tundra/walrus.svg"
+          alt="Walrus illustration"
         />
         <div class="intro">
           <span class="biome-badge">Tundra</span>

--- a/generate_animals.py
+++ b/generate_animals.py
@@ -1,6 +1,117 @@
 from pathlib import Path
+import html
+
+BIOME_STYLES = {
+    "rainforest": {
+        "label": "Rainforest",
+        "emoji": "🌴",
+        "colors": ("#0c5a3a", "#05301b"),
+    },
+    "savannah": {
+        "label": "Savannah",
+        "emoji": "🌾",
+        "colors": ("#c47a18", "#7a4510"),
+    },
+    "desert": {
+        "label": "Desert",
+        "emoji": "🌵",
+        "colors": ("#d9822a", "#a34f16"),
+    },
+    "tundra": {
+        "label": "Tundra",
+        "emoji": "❄️",
+        "colors": ("#3b6ca1", "#1b3653"),
+    },
+    "home": {
+        "label": "Biome Adventure",
+        "emoji": "🌍",
+        "colors": ("#2b6f55", "#183b2d"),
+    },
+}
+
+ANIMAL_EMOJI = {
+    "jaguar": "🐆",
+    "poison-dart-frog": "🐸",
+    "sloth": "🦥",
+    "toucan": "🦜",
+    "capuchin-monkey": "🐒",
+    "leafcutter-ant": "🐜",
+    "harpy-eagle": "🦅",
+    "green-anaconda": "🐍",
+    "orangutan": "🦧",
+    "leaf-tailed-gecko": "🦎",
+    "amazon-river-dolphin": "🐬",
+    "scarlet-macaw": "🦜",
+    "african-elephant": "🐘",
+    "lion": "🦁",
+    "cheetah": "🐆",
+    "giraffe": "🦒",
+    "zebra": "🦓",
+    "meerkat": "🐿️",
+    "wildebeest": "🐃",
+    "secretary-bird": "🦅",
+    "african-wild-dog": "🐕",
+    "hippopotamus": "🦛",
+    "ostrich": "🐦",
+    "warthog": "🐗",
+    "fennec-fox": "🦊",
+    "dromedary-camel": "🐪",
+    "gila-monster": "🦎",
+    "roadrunner": "🐦",
+    "horned-lizard": "🦎",
+    "desert-tortoise": "🐢",
+    "bark-scorpion": "🦂",
+    "kangaroo-rat": "🐭",
+    "sidewinder-rattlesnake": "🐍",
+    "arabian-oryx": "🦌",
+    "egyptian-vulture": "🦅",
+    "jerboa": "🐹",
+    "arctic-fox": "🦊",
+    "polar-bear": "🐻‍❄️",
+    "snowy-owl": "🦉",
+    "caribou": "🦌",
+    "musk-ox": "🐂",
+    "arctic-hare": "🐇",
+    "lemming": "🐭",
+    "walrus": "🦭",
+    "narwhal": "🐋",
+    "arctic-wolf": "🐺",
+    "atlantic-puffin": "🐧",
+    "ringed-seal": "🦭",
+}
 
 BASE_DIR = Path(__file__).resolve().parent
+IMG_DIR = BASE_DIR / "assets" / "img"
+
+
+def create_svg(path: Path, emoji: str, label: str, colors: tuple[str, str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    color_top, color_bottom = colors
+    svg = f"""<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 1200 800\" role=\"img\" aria-label=\"{html.escape(label)}\">\n  <defs>\n    <linearGradient id=\"bg\" x1=\"0\" y1=\"0\" x2=\"0\" y2=\"1\">\n      <stop offset=\"0%\" stop-color=\"{color_top}\" />\n      <stop offset=\"100%\" stop-color=\"{color_bottom}\" />\n    </linearGradient>\n    <radialGradient id=\"glow\" cx=\"50%\" cy=\"45%\" r=\"55%\">\n      <stop offset=\"0%\" stop-color=\"#ffffff\" stop-opacity=\"0.18\" />\n      <stop offset=\"100%\" stop-color=\"#ffffff\" stop-opacity=\"0\" />\n    </radialGradient>\n  </defs>\n  <rect width=\"1200\" height=\"800\" fill=\"url(#bg)\" rx=\"60\" />\n  <circle cx=\"900\" cy=\"140\" r=\"160\" fill=\"rgba(255, 255, 255, 0.08)\" />\n  <circle cx=\"260\" cy=\"620\" r=\"220\" fill=\"rgba(255, 255, 255, 0.07)\" />\n  <ellipse cx=\"600\" cy=\"480\" rx=\"360\" ry=\"240\" fill=\"url(#glow)\" />\n  <text x=\"600\" y=\"420\" font-size=\"260\" text-anchor=\"middle\" dominant-baseline=\"middle\" font-family=\"'Noto Color Emoji', 'Twemoji Mozilla', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif\">{html.escape(emoji)}\n  </text>\n  <text x=\"600\" y=\"640\" font-size=\"88\" text-anchor=\"middle\" fill=\"rgba(255,255,255,0.94)\" font-family=\"'Baloo 2', 'Nunito', 'Poppins', sans-serif\" font-weight=\"700\">{html.escape(label)}\n  </text>\n</svg>\n"""
+    path.write_text(svg, encoding="utf-8")
+
+
+def ensure_biome_svgs() -> None:
+    for biome, info in BIOME_STYLES.items():
+        if biome == "home":
+            filename = "home.svg"
+        else:
+            filename = f"{biome}.svg"
+        create_svg(IMG_DIR / "biomes" / filename, info["emoji"], info["label"], info["colors"])
+
+
+def ensure_animal_svgs() -> None:
+    for biome, animals_list in animals.items():
+        biome_colors = BIOME_STYLES[biome]["colors"]
+        for entry in animals_list:
+            emoji = ANIMAL_EMOJI.get(entry["slug"], "🌟")
+            label = entry["name"]
+            create_svg(
+                IMG_DIR / "animals" / biome / f"{entry['slug']}.svg",
+                emoji,
+                label,
+                biome_colors,
+            )
 
 shared_head = """<!DOCTYPE html>
 <html lang=\"en\">
@@ -1237,12 +1348,15 @@ def render_animal(biome: str, data: dict) -> str:
         "tundra": "rgba(66, 108, 163, 0.92), rgba(17, 34, 63, 0.75)",
     }
     gradient = gradients.get(biome, "rgba(20, 60, 40, 0.9), rgba(10, 30, 20, 0.75)")
+    header_image = f"../../assets/img/biomes/{biome}.svg"
+    hero_image = f"../../assets/img/animals/{biome}/{data['slug']}.svg"
+    hero_alt = f"{data['name']} illustration"
     header = (
         shared_head.format(title=f"{data['name']} Adaptations")
         + "  <body>\n"
         + "    <header\n"
         + f"      style=\"background: linear-gradient(135deg, {gradient}),\n"
-        + f"        url('{data['header_bg']}') center/cover;\"\n"
+        + f"        url('{header_image}') center/cover;\"\n"
         + "    >\n"
         + f"      <h1>{data['name']}</h1>\n"
         + f"      <p class=\"hero-text\">{data['hero_text']}</p>\n"
@@ -1255,7 +1369,7 @@ def render_animal(biome: str, data: dict) -> str:
         "tundra": "Tundra",
     }
     back_link = f"      <a class=\"back-link\" href=\"index.html\">← Back to {biome_titles[biome]} Animals</a>\n"
-    hero_section = f"""      <div class=\"animal-hero\">\n        <img\n          src=\"{data['image']}\"\n          alt=\"{data['image_alt']}\"\n        />\n        <div class=\"intro\">\n          <span class=\"biome-badge\">{biome_titles[biome]}</span>\n          <h2>{data['intro_title']}</h2>\n          <p>\n            {data['intro_body']}\n          </p>\n        </div>\n      </div>\n"""
+    hero_section = f"""      <div class=\"animal-hero\">\n        <img\n          src=\"{hero_image}\"\n          alt=\"{hero_alt}\"\n        />\n        <div class=\"intro\">\n          <span class=\"biome-badge\">{biome_titles[biome]}</span>\n          <h2>{data['intro_title']}</h2>\n          <p>\n            {data['intro_body']}\n          </p>\n        </div>\n      </div>\n"""
     adaptation_blocks = []
     for item in data["adaptations"]:
         adaptation_blocks.append(
@@ -1267,6 +1381,8 @@ def render_animal(biome: str, data: dict) -> str:
 
 
 def main() -> None:
+    ensure_biome_svgs()
+    ensure_animal_svgs()
     for biome, animals_list in animals.items():
         biome_dir = BASE_DIR / "biomes" / biome
         biome_dir.mkdir(parents=True, exist_ok=True)

--- a/index.html
+++ b/index.html
@@ -22,45 +22,37 @@
     </header>
     <main class="container">
       <div class="biome-grid">
-        <a
-          class="card"
-          href="biomes/rainforest/index.html"
-          style="background: linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.45)),
-            url('https://images.unsplash.com/photo-1513836279014-a89f7a76ae86?auto=format&fit=crop&w=900&q=80') center/cover;"
-        >
+        <a class="card" href="biomes/rainforest/index.html">
+          <div class="card-image">
+            <img src="assets/img/biomes/rainforest.svg" alt="Rainforest biome illustration" />
+          </div>
           <div class="card-content">
             <h2>Rainforest</h2>
             <p>Dripping leaves, bright colors, and animals that love the trees.</p>
           </div>
         </a>
-        <a
-          class="card"
-          href="biomes/savannah/index.html"
-          style="background: linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.45)),
-            url('https://images.unsplash.com/photo-1508672019048-805c876b67e2?auto=format&fit=crop&w=900&q=80') center/cover;"
-        >
+        <a class="card" href="biomes/savannah/index.html">
+          <div class="card-image">
+            <img src="assets/img/biomes/savannah.svg" alt="Savannah biome illustration" />
+          </div>
           <div class="card-content">
             <h2>Savannah</h2>
             <p>Warm grasslands where tall grasses hide speedy hunters.</p>
           </div>
         </a>
-        <a
-          class="card"
-          href="biomes/desert/index.html"
-          style="background: linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.45)),
-            url('https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=900&q=80') center/cover;"
-        >
+        <a class="card" href="biomes/desert/index.html">
+          <div class="card-image">
+            <img src="assets/img/biomes/desert.svg" alt="Desert biome illustration" />
+          </div>
           <div class="card-content">
             <h2>Desert</h2>
             <p>Sunny sands and rocky cliffs that creatures call home.</p>
           </div>
         </a>
-        <a
-          class="card"
-          href="biomes/tundra/index.html"
-          style="background: linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.45)),
-            url('https://images.unsplash.com/photo-1476610182048-b716b8518aae?auto=format&fit=crop&w=900&q=80') center/cover;"
-        >
+        <a class="card" href="biomes/tundra/index.html">
+          <div class="card-image">
+            <img src="assets/img/biomes/tundra.svg" alt="Tundra biome illustration" />
+          </div>
           <div class="card-content">
             <h2>Tundra</h2>
             <p>Frozen lands where fur and feathers keep friends warm.</p>


### PR DESCRIPTION
## Summary
- generate reusable SVG illustrations for each biome and animal and point the generator at the local assets
- refresh the biome index cards and styling to showcase the new illustrations instead of remote photos
- add a meSpeak-backed speech playback path so adaptation audio no longer depends on the device voice

## Testing
- python generate_animals.py

------
https://chatgpt.com/codex/tasks/task_e_68cae49cb58883318032e2bc8a13a524