### PR TITLE
Add kid-friendly learn-more links and videos to biome pages

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -197,6 +197,57 @@ header p {
   font-size: 1.1rem;
 }
 
+.learn-more,
+.video-section {
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: var(--shadow);
+  padding: 1.5rem;
+  margin-top: 2.5rem;
+}
+
+.learn-more h3,
+.video-section h3 {
+  font-size: 1.45rem;
+  color: var(--primary-color);
+  margin-bottom: 0.75rem;
+}
+
+.learn-more p,
+.video-section p {
+  font-size: 1.05rem;
+}
+
+.learn-more-link {
+  color: var(--accent-color);
+  font-weight: 700;
+  text-decoration: underline;
+}
+
+.video-wrapper {
+  position: relative;
+  padding-top: 56.25%;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: var(--shadow);
+  margin-top: 1rem;
+}
+
+.video-wrapper iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.video-caption {
+  margin-top: 0.75rem;
+  font-size: 0.95rem;
+  text-align: center;
+  color: #4c5a67;
+}
+
 .speak-button {
   margin-top: 1rem;
   background: var(--accent-color);

--- a/biomes/desert/arabian-oryx.html
+++ b/biomes/desert/arabian-oryx.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Arabian Oryx</h3>
+        <p>
+          <a class="learn-more-link" href="https://www.dkfindout.com/us/animals-and-nature/hoofed-mammals/oryx/" target="_blank" rel="noopener">Learn more from DK Find Out!: Oryx</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Arabian Oryx in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=arabian+oryx+for+kids"
+            title="Arabian oryx videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Arabian oryx videos for kids</p>
+      </section>
     </main>
     <footer>Graceful moves help the oryx find what it needs.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/desert/bark-scorpion.html
+++ b/biomes/desert/bark-scorpion.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Bark Scorpion</h3>
+        <p>
+          <a class="learn-more-link" href="https://www.desertmuseum.org/kids/oz/long-fact-sheets/bark_scorpion.php" target="_blank" rel="noopener">Learn more from Desert Museum Kids: Bark Scorpion</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Bark Scorpion in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=bark+scorpion+for+kids"
+            title="Bark scorpion videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Bark scorpion videos for kids</p>
+      </section>
     </main>
     <footer>Quiet feet and glowing armor guide the bark scorpion.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/desert/desert-tortoise.html
+++ b/biomes/desert/desert-tortoise.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Desert Tortoise</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/reptiles/facts/desert-tortoise" target="_blank" rel="noopener">Learn more from National Geographic Kids: Desert Tortoise</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Desert Tortoise in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=desert+tortoise+for+kids"
+            title="Desert tortoise videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Desert tortoise videos for kids</p>
+      </section>
     </main>
     <footer>Patience helps the desert tortoise last through droughts.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/desert/dromedary-camel.html
+++ b/biomes/desert/dromedary-camel.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Dromedary Camel</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.kiddle.co/Dromedary" target="_blank" rel="noopener">Learn more from Kiddle: Dromedary Camel</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Dromedary Camel in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=dromedary+camel+for+kids"
+            title="Dromedary camel videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Dromedary camel videos for kids</p>
+      </section>
     </main>
     <footer>Camels are expert travelers of dry places.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/desert/egyptian-vulture.html
+++ b/biomes/desert/egyptian-vulture.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Egyptian Vulture</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.kiddle.co/Egyptian_vulture" target="_blank" rel="noopener">Learn more from Kiddle: Egyptian Vulture</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Egyptian Vulture in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=egyptian+vulture+for+kids"
+            title="Egyptian vulture videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Egyptian vulture videos for kids</p>
+      </section>
     </main>
     <footer>Even leftovers become useful with a clever vulture.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/desert/fennec-fox.html
+++ b/biomes/desert/fennec-fox.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Fennec Fox</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/fennec-fox" target="_blank" rel="noopener">Learn more from National Geographic Kids: Fennec Fox</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Fennec Fox in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=fennec+fox+for+kids"
+            title="Fennec fox videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Fennec fox videos for kids</p>
+      </section>
     </main>
     <footer>Staying cool helps fennec foxes thrive in the desert.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/desert/gila-monster.html
+++ b/biomes/desert/gila-monster.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Gila Monster</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/reptiles/facts/gila-monster" target="_blank" rel="noopener">Learn more from National Geographic Kids: Gila Monster</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Gila Monster in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=gila+monster+for+kids"
+            title="Gila monster videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Gila monster videos for kids</p>
+      </section>
     </main>
     <footer>Patience and poison give the Gila monster power.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/desert/horned-lizard.html
+++ b/biomes/desert/horned-lizard.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Horned Lizard</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/reptiles/facts/horned-lizard" target="_blank" rel="noopener">Learn more from National Geographic Kids: Horned Lizard</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Horned Lizard in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=horned+lizard+for+kids"
+            title="Horned lizard videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Horned lizard videos for kids</p>
+      </section>
     </main>
     <footer>Camouflage and courage protect the horned lizard.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/desert/index.html
+++ b/biomes/desert/index.html
@@ -134,6 +134,32 @@
           </div>
         </a>
       </div>
+      <section class="learn-more">
+        <h3>Learn more about the Desert</h3>
+        <p>
+          <a
+            class="learn-more-link"
+            href="https://kids.nationalgeographic.com/nature/habitats/article/deserts"
+            target="_blank"
+            rel="noopener"
+          >
+            Discover desert facts on National Geographic Kids
+          </a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch desert wildlife explore</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=desert+biome+for+kids"
+            title="Desert biome videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Desert biome videos for kids</p>
+      </section>
     </main>
     <footer>Pick an animal to discover desert survival secrets!</footer>
   </body>

--- a/biomes/desert/jerboa.html
+++ b/biomes/desert/jerboa.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Jerboa</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.kiddle.co/Jerboa" target="_blank" rel="noopener">Learn more from Kiddle: Jerboa</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Jerboa in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=jerboa+for+kids"
+            title="Jerboa videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Jerboa videos for kids</p>
+      </section>
     </main>
     <footer>Jumps and burrows protect the jerboa.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/desert/kangaroo-rat.html
+++ b/biomes/desert/kangaroo-rat.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Kangaroo Rat</h3>
+        <p>
+          <a class="learn-more-link" href="https://www.coolkidfacts.com/kangaroo-rat-facts/" target="_blank" rel="noopener">Learn more from Cool Kid Facts: Kangaroo Rat</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Kangaroo Rat in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=kangaroo+rat+for+kids"
+            title="Kangaroo rat videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Kangaroo rat videos for kids</p>
+      </section>
     </main>
     <footer>Hopping and storing keep kangaroo rats healthy.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/desert/roadrunner.html
+++ b/biomes/desert/roadrunner.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Roadrunner</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/birds/facts/roadrunner" target="_blank" rel="noopener">Learn more from National Geographic Kids: Roadrunner</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Roadrunner in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=roadrunner+bird+for+kids"
+            title="Roadrunner videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Roadrunner videos for kids</p>
+      </section>
     </main>
     <footer>Speed and smarts help roadrunners stay safe.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/desert/sidewinder-rattlesnake.html
+++ b/biomes/desert/sidewinder-rattlesnake.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Sidewinder Rattlesnake</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/reptiles/facts/sidewinder" target="_blank" rel="noopener">Learn more from National Geographic Kids: Sidewinder</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Sidewinder Rattlesnake in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=sidewinder+rattlesnake+for+kids"
+            title="Sidewinder rattlesnake videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Sidewinder rattlesnake videos for kids</p>
+      </section>
     </main>
     <footer>Smart moves help the sidewinder stay cool.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/rainforest/amazon-river-dolphin.html
+++ b/biomes/rainforest/amazon-river-dolphin.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Amazon River Dolphin</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/amazon-river-dolphin" target="_blank" rel="noopener">Learn more from National Geographic Kids: Amazon River Dolphin</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Amazon River Dolphin in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=amazon+river+dolphin+for+kids"
+            title="Amazon river dolphin videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Amazon river dolphin videos for kids</p>
+      </section>
     </main>
     <footer>The boto proves rivers can hide colorful surprises.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/rainforest/capuchin-monkey.html
+++ b/biomes/rainforest/capuchin-monkey.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Capuchin Monkey</h3>
+        <p>
+          <a class="learn-more-link" href="https://www.coolkidfacts.com/capuchin-monkey-facts/" target="_blank" rel="noopener">Learn more from Cool Kid Facts: Capuchin Monkey</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Capuchin Monkey in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=capuchin+monkey+for+kids"
+            title="Capuchin monkey videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Capuchin monkey videos for kids</p>
+      </section>
     </main>
     <footer>Clever hands and teamwork keep capuchins safe.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/rainforest/green-anaconda.html
+++ b/biomes/rainforest/green-anaconda.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Green Anaconda</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/reptiles/facts/green-anaconda" target="_blank" rel="noopener">Learn more from National Geographic Kids: Green Anaconda</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Green Anaconda in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=green+anaconda+for+kids"
+            title="Green anaconda videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Green anaconda videos for kids</p>
+      </section>
     </main>
     <footer>Slow and steady swimming makes the anaconda successful.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/rainforest/harpy-eagle.html
+++ b/biomes/rainforest/harpy-eagle.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Harpy Eagle</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/birds/facts/harpy-eagle" target="_blank" rel="noopener">Learn more from National Geographic Kids: Harpy Eagle</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Harpy Eagle in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=harpy+eagle+for+kids"
+            title="Harpy eagle videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Harpy eagle videos for kids</p>
+      </section>
     </main>
     <footer>Harpy eagles are gentle giants to their chicks but fierce hunters in flight.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/rainforest/index.html
+++ b/biomes/rainforest/index.html
@@ -135,6 +135,32 @@
           </div>
         </a>
       </div>
+      <section class="learn-more">
+        <h3>Learn more about the Rainforest</h3>
+        <p>
+          <a
+            class="learn-more-link"
+            href="https://kids.nationalgeographic.com/nature/habitats/article/rain-forests"
+            target="_blank"
+            rel="noopener"
+          >
+            Discover rainforest secrets on National Geographic Kids
+          </a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch rainforest life in motion</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=rainforest+animals+for+kids"
+            title="Rainforest animal videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Rainforest animal videos for kids</p>
+      </section>
     </main>
     <footer>Pick an animal to discover rainforest superpowers!</footer>
   </body>

--- a/biomes/rainforest/jaguar.html
+++ b/biomes/rainforest/jaguar.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Jaguar</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/jaguar" target="_blank" rel="noopener">Learn more from National Geographic Kids: Jaguar</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Jaguar in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=jaguar+for+kids"
+            title="Jaguar videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Jaguar videos for kids</p>
+      </section>
     </main>
     <footer>Jaguars show how strength and silence work together.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/rainforest/leaf-tailed-gecko.html
+++ b/biomes/rainforest/leaf-tailed-gecko.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Leaf-Tailed Gecko</h3>
+        <p>
+          <a class="learn-more-link" href="https://www.natgeokids.com/uk/discover/animals/reptiles/gecko-facts/" target="_blank" rel="noopener">Learn more from Nat Geo Kids UK: Gecko Facts</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Leaf-Tailed Gecko in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=leaf+tailed+gecko+for+kids"
+            title="Leaf-tailed gecko videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Leaf-tailed gecko videos for kids</p>
+      </section>
     </main>
     <footer>Sometimes the best defense is becoming invisible!</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/rainforest/leafcutter-ant.html
+++ b/biomes/rainforest/leafcutter-ant.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Leafcutter Ant</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.kiddle.co/Leafcutter_ant" target="_blank" rel="noopener">Learn more from Kiddle: Leafcutter Ant</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Leafcutter Ant in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=leafcutter+ant+for+kids"
+            title="Leafcutter ant videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Leafcutter ant videos for kids</p>
+      </section>
     </main>
     <footer>Leafcutter ants prove teamwork makes mighty results.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/rainforest/orangutan.html
+++ b/biomes/rainforest/orangutan.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Orangutan</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/orangutan" target="_blank" rel="noopener">Learn more from National Geographic Kids: Orangutan</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Orangutan in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=orangutan+for+kids"
+            title="Orangutan videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Orangutan videos for kids</p>
+      </section>
     </main>
     <footer>Caring and clever orangutans remind us to protect the forest.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/rainforest/poison-dart-frog.html
+++ b/biomes/rainforest/poison-dart-frog.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Poison Dart Frog</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/amphibians/facts/poison-dart-frog" target="_blank" rel="noopener">Learn more from National Geographic Kids: Poison Dart Frog</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Poison Dart Frog in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=poison+dart+frog+for+kids"
+            title="Poison dart frog videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Poison dart frog videos for kids</p>
+      </section>
     </main>
     <footer>Color can be a powerful rainforest shield!</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/rainforest/scarlet-macaw.html
+++ b/biomes/rainforest/scarlet-macaw.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Scarlet Macaw</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/birds/facts/scarlet-macaw" target="_blank" rel="noopener">Learn more from National Geographic Kids: Scarlet Macaw</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Scarlet Macaw in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=scarlet+macaw+for+kids"
+            title="Scarlet macaw videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Scarlet macaw videos for kids</p>
+      </section>
     </main>
     <footer>Bright feathers and loud voices make macaws unforgettable.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/rainforest/sloth.html
+++ b/biomes/rainforest/sloth.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Sloth</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/sloth" target="_blank" rel="noopener">Learn more from National Geographic Kids: Sloth</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Sloth in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=sloth+for+kids"
+            title="Sloth videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Sloth videos for kids</p>
+      </section>
     </main>
     <footer>Sometimes slow and steady wins in the rainforest!</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/rainforest/toucan.html
+++ b/biomes/rainforest/toucan.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Toucan</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/birds/facts/toco-toucan" target="_blank" rel="noopener">Learn more from National Geographic Kids: Toucan</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Toucan in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=toucan+for+kids"
+            title="Toucan videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Toucan videos for kids</p>
+      </section>
     </main>
     <footer>That colorful beak is more than just for show!</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/savannah/african-elephant.html
+++ b/biomes/savannah/african-elephant.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the African Elephant</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/african-elephant" target="_blank" rel="noopener">Learn more from National Geographic Kids: African Elephant</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the African Elephant in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=african+elephant+for+kids"
+            title="African elephant videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">African elephant videos for kids</p>
+      </section>
     </main>
     <footer>Elephants show the strength of family care.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/savannah/african-wild-dog.html
+++ b/biomes/savannah/african-wild-dog.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the African Wild Dog</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/african-wild-dog" target="_blank" rel="noopener">Learn more from National Geographic Kids: African Wild Dog</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the African Wild Dog in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=african+wild+dog+for+kids"
+            title="African wild dog videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">African wild dog videos for kids</p>
+      </section>
     </main>
     <footer>Kindness keeps the painted dogs strong.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/savannah/cheetah.html
+++ b/biomes/savannah/cheetah.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Cheetah</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/cheetah" target="_blank" rel="noopener">Learn more from National Geographic Kids: Cheetah</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Cheetah in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=cheetah+for+kids"
+            title="Cheetah videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Cheetah videos for kids</p>
+      </section>
     </main>
     <footer>Cheetahs are built from nose to tail for quick dashes.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/savannah/giraffe.html
+++ b/biomes/savannah/giraffe.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Giraffe</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/giraffe" target="_blank" rel="noopener">Learn more from National Geographic Kids: Giraffe</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Giraffe in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=giraffe+for+kids"
+            title="Giraffe videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Giraffe videos for kids</p>
+      </section>
     </main>
     <footer>High heads keep giraffes safe and well fed.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/savannah/hippopotamus.html
+++ b/biomes/savannah/hippopotamus.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Hippopotamus</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/hippopotamus" target="_blank" rel="noopener">Learn more from National Geographic Kids: Hippopotamus</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Hippopotamus in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=hippopotamus+for+kids"
+            title="Hippopotamus videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Hippopotamus videos for kids</p>
+      </section>
     </main>
     <footer>Water and land both feel like home to hippos.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/savannah/index.html
+++ b/biomes/savannah/index.html
@@ -134,6 +134,32 @@
           </div>
         </a>
       </div>
+      <section class="learn-more">
+        <h3>Learn more about the Savannah</h3>
+        <p>
+          <a
+            class="learn-more-link"
+            href="https://kids.nationalgeographic.com/nature/habitats/article/savanna"
+            target="_blank"
+            rel="noopener"
+          >
+            Explore savanna facts on National Geographic Kids
+          </a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch savanna animals roam</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=savanna+animals+for+kids"
+            title="Savanna animal videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Savanna animal videos for kids</p>
+      </section>
     </main>
     <footer>Pick an animal to discover savannah survival skills!</footer>
   </body>

--- a/biomes/savannah/lion.html
+++ b/biomes/savannah/lion.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Lion</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/lion" target="_blank" rel="noopener">Learn more from National Geographic Kids: Lion</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Lion in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=lion+for+kids"
+            title="Lion videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Lion videos for kids</p>
+      </section>
     </main>
     <footer>Lions prove that sharing jobs helps everyone eat.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/savannah/meerkat.html
+++ b/biomes/savannah/meerkat.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Meerkat</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/meerkat" target="_blank" rel="noopener">Learn more from National Geographic Kids: Meerkat</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Meerkat in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=meerkat+for+kids"
+            title="Meerkat videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Meerkat videos for kids</p>
+      </section>
     </main>
     <footer>Sharing chores keeps meerkat mobs happy.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/savannah/ostrich.html
+++ b/biomes/savannah/ostrich.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Ostrich</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/birds/facts/ostrich" target="_blank" rel="noopener">Learn more from National Geographic Kids: Ostrich</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Ostrich in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=ostrich+for+kids"
+            title="Ostrich videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Ostrich videos for kids</p>
+      </section>
     </main>
     <footer>Strong legs keep ostriches safe on open plains.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/savannah/secretary-bird.html
+++ b/biomes/savannah/secretary-bird.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Secretary Bird</h3>
+        <p>
+          <a class="learn-more-link" href="https://www.kidzone.ws/africa/secretary-bird.htm" target="_blank" rel="noopener">Learn more from KidZone: Secretary Bird</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Secretary Bird in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=secretary+bird+for+kids"
+            title="Secretary bird videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Secretary bird videos for kids</p>
+      </section>
     </main>
     <footer>Tall legs and sharp eyes make the secretary bird special.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/savannah/warthog.html
+++ b/biomes/savannah/warthog.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Warthog</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/warthog" target="_blank" rel="noopener">Learn more from National Geographic Kids: Warthog</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Warthog in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=warthog+for+kids"
+            title="Warthog videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Warthog videos for kids</p>
+      </section>
     </main>
     <footer>Bravery and burrows keep warthogs safe.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/savannah/wildebeest.html
+++ b/biomes/savannah/wildebeest.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Wildebeest</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.kiddle.co/Wildebeest" target="_blank" rel="noopener">Learn more from Kiddle: Wildebeest</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Wildebeest in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=wildebeest+for+kids"
+            title="Wildebeest videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Wildebeest videos for kids</p>
+      </section>
     </main>
     <footer>Traveling together keeps wildebeest safe and fed.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/savannah/zebra.html
+++ b/biomes/savannah/zebra.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Zebra</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/plains-zebra" target="_blank" rel="noopener">Learn more from National Geographic Kids: Plains Zebra</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Zebra in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=zebra+for+kids"
+            title="Zebra videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Zebra videos for kids</p>
+      </section>
     </main>
     <footer>Zebras prove that friendship can be a superpower.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/tundra/arctic-fox.html
+++ b/biomes/tundra/arctic-fox.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Arctic Fox</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/arctic-fox" target="_blank" rel="noopener">Learn more from National Geographic Kids: Arctic Fox</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Arctic Fox in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=arctic+fox+for+kids"
+            title="Arctic fox videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Arctic fox videos for kids</p>
+      </section>
     </main>
     <footer>Cozy fur keeps the arctic fox comfy in cold weather.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/tundra/arctic-hare.html
+++ b/biomes/tundra/arctic-hare.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Arctic Hare</h3>
+        <p>
+          <a class="learn-more-link" href="https://www.natgeokids.com/uk/discover/animals/animals-facts/arctic-hare-facts/" target="_blank" rel="noopener">Learn more from Nat Geo Kids UK: Arctic Hare</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Arctic Hare in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=arctic+hare+for+kids"
+            title="Arctic hare videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Arctic hare videos for kids</p>
+      </section>
     </main>
     <footer>Speed and camouflage help the Arctic hare survive.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/tundra/arctic-wolf.html
+++ b/biomes/tundra/arctic-wolf.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Arctic Wolf</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/arctic-wolf" target="_blank" rel="noopener">Learn more from National Geographic Kids: Arctic Wolf</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Arctic Wolf in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=arctic+wolf+for+kids"
+            title="Arctic wolf videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Arctic wolf videos for kids</p>
+      </section>
     </main>
     <footer>Teamwork helps arctic wolves through winter.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/tundra/atlantic-puffin.html
+++ b/biomes/tundra/atlantic-puffin.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Atlantic Puffin</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/birds/facts/atlantic-puffin" target="_blank" rel="noopener">Learn more from National Geographic Kids: Atlantic Puffin</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Atlantic Puffin in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=atlantic+puffin+for+kids"
+            title="Atlantic puffin videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Atlantic puffin videos for kids</p>
+      </section>
     </main>
     <footer>Puffins are acrobats in the air and sea.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/tundra/caribou.html
+++ b/biomes/tundra/caribou.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Caribou</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/reindeer" target="_blank" rel="noopener">Learn more from National Geographic Kids: Reindeer/Caribou</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Caribou in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=caribou+for+kids"
+            title="Caribou videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Caribou videos for kids</p>
+      </section>
     </main>
     <footer>Caribou teach us about long-distance teamwork.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/tundra/index.html
+++ b/biomes/tundra/index.html
@@ -135,6 +135,32 @@
           </div>
         </a>
       </div>
+      <section class="learn-more">
+        <h3>Learn more about the Tundra</h3>
+        <p>
+          <a
+            class="learn-more-link"
+            href="https://kids.nationalgeographic.com/nature/habitats/article/tundra"
+            target="_blank"
+            rel="noopener"
+          >
+            Explore tundra facts on National Geographic Kids
+          </a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch tundra animals thrive</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=tundra+animals+for+kids"
+            title="Tundra animal videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Tundra animal videos for kids</p>
+      </section>
     </main>
     <footer>Pick an animal to discover tundra survival skills!</footer>
   </body>

--- a/biomes/tundra/lemming.html
+++ b/biomes/tundra/lemming.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Lemming</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.kiddle.co/Lemming" target="_blank" rel="noopener">Learn more from Kiddle: Lemming</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Lemming in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=lemming+for+kids"
+            title="Lemming videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Lemming videos for kids</p>
+      </section>
     </main>
     <footer>Even tiny lemmings have big survival skills.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/tundra/musk-ox.html
+++ b/biomes/tundra/musk-ox.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Musk Ox</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/musk-ox" target="_blank" rel="noopener">Learn more from National Geographic Kids: Musk Ox</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Musk Ox in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=musk+ox+for+kids"
+            title="Musk ox videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Musk ox videos for kids</p>
+      </section>
     </main>
     <footer>Togetherness keeps musk oxen safe from storms and predators.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/tundra/narwhal.html
+++ b/biomes/tundra/narwhal.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Narwhal</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/narwhal" target="_blank" rel="noopener">Learn more from National Geographic Kids: Narwhal</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Narwhal in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=narwhal+for+kids"
+            title="Narwhal videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Narwhal videos for kids</p>
+      </section>
     </main>
     <footer>Narwhals prove the Arctic is full of wonders.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/tundra/polar-bear.html
+++ b/biomes/tundra/polar-bear.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Polar Bear</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/polar-bear" target="_blank" rel="noopener">Learn more from National Geographic Kids: Polar Bear</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Polar Bear in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=polar+bear+for+kids"
+            title="Polar bear videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Polar bear videos for kids</p>
+      </section>
     </main>
     <footer>Polar bears are perfectly built for icy adventures.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/tundra/ringed-seal.html
+++ b/biomes/tundra/ringed-seal.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Ringed Seal</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.kiddle.co/Ringed_seal" target="_blank" rel="noopener">Learn more from Kiddle: Ringed Seal</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Ringed Seal in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=ringed+seal+for+kids"
+            title="Ringed seal videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Ringed seal videos for kids</p>
+      </section>
     </main>
     <footer>Ringed seals are masters of snowy hideouts.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/tundra/snowy-owl.html
+++ b/biomes/tundra/snowy-owl.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Snowy Owl</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/birds/facts/snowy-owl" target="_blank" rel="noopener">Learn more from National Geographic Kids: Snowy Owl</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Snowy Owl in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=snowy+owl+for+kids"
+            title="Snowy owl videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Snowy owl videos for kids</p>
+      </section>
     </main>
     <footer>Snowy owls are patient watchers of the tundra.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/biomes/tundra/walrus.html
+++ b/biomes/tundra/walrus.html
@@ -73,6 +73,25 @@
           </button>
         </div>
       </section>
+      <section class="learn-more">
+        <h3>Keep exploring the Walrus</h3>
+        <p>
+          <a class="learn-more-link" href="https://kids.nationalgeographic.com/animals/mammals/facts/walrus" target="_blank" rel="noopener">Learn more from National Geographic Kids: Walrus</a>
+        </p>
+      </section>
+      <section class="video-section">
+        <h3>Watch the Walrus in action</h3>
+        <div class="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed?listType=search&list=walrus+for+kids"
+            title="Walrus videos for kids"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <p class="video-caption">Walrus videos for kids</p>
+      </section>
     </main>
     <footer>Walruses love chilly waves and cozy naps on ice.</footer>
     <script src="../../assets/js/script.js"></script>

--- a/generate_animals.py
+++ b/generate_animals.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from urllib.parse import quote_plus
 import html
 
 BIOME_STYLES = {
@@ -78,6 +79,297 @@ ANIMAL_EMOJI = {
     "arctic-wolf": "🐺",
     "atlantic-puffin": "🐧",
     "ringed-seal": "🦭",
+}
+
+ANIMAL_RESOURCES = {
+    "jaguar": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/jaguar",
+        "learn_more_label": "National Geographic Kids: Jaguar",
+        "video_query": "jaguar for kids",
+        "video_title": "Jaguar videos for kids",
+    },
+    "poison-dart-frog": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/amphibians/facts/poison-dart-frog",
+        "learn_more_label": "National Geographic Kids: Poison Dart Frog",
+        "video_query": "poison dart frog for kids",
+        "video_title": "Poison dart frog videos for kids",
+    },
+    "sloth": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/sloth",
+        "learn_more_label": "National Geographic Kids: Sloth",
+        "video_query": "sloth for kids",
+        "video_title": "Sloth videos for kids",
+    },
+    "toucan": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/birds/facts/toco-toucan",
+        "learn_more_label": "National Geographic Kids: Toucan",
+        "video_query": "toucan for kids",
+        "video_title": "Toucan videos for kids",
+    },
+    "capuchin-monkey": {
+        "learn_more_url": "https://www.coolkidfacts.com/capuchin-monkey-facts/",
+        "learn_more_label": "Cool Kid Facts: Capuchin Monkey",
+        "video_query": "capuchin monkey for kids",
+        "video_title": "Capuchin monkey videos for kids",
+    },
+    "leafcutter-ant": {
+        "learn_more_url": "https://kids.kiddle.co/Leafcutter_ant",
+        "learn_more_label": "Kiddle: Leafcutter Ant",
+        "video_query": "leafcutter ant for kids",
+        "video_title": "Leafcutter ant videos for kids",
+    },
+    "harpy-eagle": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/birds/facts/harpy-eagle",
+        "learn_more_label": "National Geographic Kids: Harpy Eagle",
+        "video_query": "harpy eagle for kids",
+        "video_title": "Harpy eagle videos for kids",
+    },
+    "green-anaconda": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/reptiles/facts/green-anaconda",
+        "learn_more_label": "National Geographic Kids: Green Anaconda",
+        "video_query": "green anaconda for kids",
+        "video_title": "Green anaconda videos for kids",
+    },
+    "orangutan": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/orangutan",
+        "learn_more_label": "National Geographic Kids: Orangutan",
+        "video_query": "orangutan for kids",
+        "video_title": "Orangutan videos for kids",
+    },
+    "leaf-tailed-gecko": {
+        "learn_more_url": "https://www.natgeokids.com/uk/discover/animals/reptiles/gecko-facts/",
+        "learn_more_label": "Nat Geo Kids UK: Gecko Facts",
+        "video_query": "leaf tailed gecko for kids",
+        "video_title": "Leaf-tailed gecko videos for kids",
+    },
+    "amazon-river-dolphin": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/amazon-river-dolphin",
+        "learn_more_label": "National Geographic Kids: Amazon River Dolphin",
+        "video_query": "amazon river dolphin for kids",
+        "video_title": "Amazon river dolphin videos for kids",
+    },
+    "scarlet-macaw": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/birds/facts/scarlet-macaw",
+        "learn_more_label": "National Geographic Kids: Scarlet Macaw",
+        "video_query": "scarlet macaw for kids",
+        "video_title": "Scarlet macaw videos for kids",
+    },
+    "african-elephant": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/african-elephant",
+        "learn_more_label": "National Geographic Kids: African Elephant",
+        "video_query": "african elephant for kids",
+        "video_title": "African elephant videos for kids",
+    },
+    "lion": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/lion",
+        "learn_more_label": "National Geographic Kids: Lion",
+        "video_query": "lion for kids",
+        "video_title": "Lion videos for kids",
+    },
+    "cheetah": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/cheetah",
+        "learn_more_label": "National Geographic Kids: Cheetah",
+        "video_query": "cheetah for kids",
+        "video_title": "Cheetah videos for kids",
+    },
+    "giraffe": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/giraffe",
+        "learn_more_label": "National Geographic Kids: Giraffe",
+        "video_query": "giraffe for kids",
+        "video_title": "Giraffe videos for kids",
+    },
+    "zebra": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/plains-zebra",
+        "learn_more_label": "National Geographic Kids: Plains Zebra",
+        "video_query": "zebra for kids",
+        "video_title": "Zebra videos for kids",
+    },
+    "meerkat": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/meerkat",
+        "learn_more_label": "National Geographic Kids: Meerkat",
+        "video_query": "meerkat for kids",
+        "video_title": "Meerkat videos for kids",
+    },
+    "wildebeest": {
+        "learn_more_url": "https://kids.kiddle.co/Wildebeest",
+        "learn_more_label": "Kiddle: Wildebeest",
+        "video_query": "wildebeest for kids",
+        "video_title": "Wildebeest videos for kids",
+    },
+    "secretary-bird": {
+        "learn_more_url": "https://www.kidzone.ws/africa/secretary-bird.htm",
+        "learn_more_label": "KidZone: Secretary Bird",
+        "video_query": "secretary bird for kids",
+        "video_title": "Secretary bird videos for kids",
+    },
+    "african-wild-dog": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/african-wild-dog",
+        "learn_more_label": "National Geographic Kids: African Wild Dog",
+        "video_query": "african wild dog for kids",
+        "video_title": "African wild dog videos for kids",
+    },
+    "hippopotamus": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/hippopotamus",
+        "learn_more_label": "National Geographic Kids: Hippopotamus",
+        "video_query": "hippopotamus for kids",
+        "video_title": "Hippopotamus videos for kids",
+    },
+    "ostrich": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/birds/facts/ostrich",
+        "learn_more_label": "National Geographic Kids: Ostrich",
+        "video_query": "ostrich for kids",
+        "video_title": "Ostrich videos for kids",
+    },
+    "warthog": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/warthog",
+        "learn_more_label": "National Geographic Kids: Warthog",
+        "video_query": "warthog for kids",
+        "video_title": "Warthog videos for kids",
+    },
+    "fennec-fox": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/fennec-fox",
+        "learn_more_label": "National Geographic Kids: Fennec Fox",
+        "video_query": "fennec fox for kids",
+        "video_title": "Fennec fox videos for kids",
+    },
+    "dromedary-camel": {
+        "learn_more_url": "https://kids.kiddle.co/Dromedary",
+        "learn_more_label": "Kiddle: Dromedary Camel",
+        "video_query": "dromedary camel for kids",
+        "video_title": "Dromedary camel videos for kids",
+    },
+    "gila-monster": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/reptiles/facts/gila-monster",
+        "learn_more_label": "National Geographic Kids: Gila Monster",
+        "video_query": "gila monster for kids",
+        "video_title": "Gila monster videos for kids",
+    },
+    "roadrunner": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/birds/facts/roadrunner",
+        "learn_more_label": "National Geographic Kids: Roadrunner",
+        "video_query": "roadrunner bird for kids",
+        "video_title": "Roadrunner videos for kids",
+    },
+    "horned-lizard": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/reptiles/facts/horned-lizard",
+        "learn_more_label": "National Geographic Kids: Horned Lizard",
+        "video_query": "horned lizard for kids",
+        "video_title": "Horned lizard videos for kids",
+    },
+    "desert-tortoise": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/reptiles/facts/desert-tortoise",
+        "learn_more_label": "National Geographic Kids: Desert Tortoise",
+        "video_query": "desert tortoise for kids",
+        "video_title": "Desert tortoise videos for kids",
+    },
+    "bark-scorpion": {
+        "learn_more_url": "https://www.desertmuseum.org/kids/oz/long-fact-sheets/bark_scorpion.php",
+        "learn_more_label": "Desert Museum Kids: Bark Scorpion",
+        "video_query": "bark scorpion for kids",
+        "video_title": "Bark scorpion videos for kids",
+    },
+    "kangaroo-rat": {
+        "learn_more_url": "https://www.coolkidfacts.com/kangaroo-rat-facts/",
+        "learn_more_label": "Cool Kid Facts: Kangaroo Rat",
+        "video_query": "kangaroo rat for kids",
+        "video_title": "Kangaroo rat videos for kids",
+    },
+    "sidewinder-rattlesnake": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/reptiles/facts/sidewinder",
+        "learn_more_label": "National Geographic Kids: Sidewinder",
+        "video_query": "sidewinder rattlesnake for kids",
+        "video_title": "Sidewinder rattlesnake videos for kids",
+    },
+    "arabian-oryx": {
+        "learn_more_url": "https://www.dkfindout.com/us/animals-and-nature/hoofed-mammals/oryx/",
+        "learn_more_label": "DK Find Out!: Oryx",
+        "video_query": "arabian oryx for kids",
+        "video_title": "Arabian oryx videos for kids",
+    },
+    "egyptian-vulture": {
+        "learn_more_url": "https://kids.kiddle.co/Egyptian_vulture",
+        "learn_more_label": "Kiddle: Egyptian Vulture",
+        "video_query": "egyptian vulture for kids",
+        "video_title": "Egyptian vulture videos for kids",
+    },
+    "jerboa": {
+        "learn_more_url": "https://kids.kiddle.co/Jerboa",
+        "learn_more_label": "Kiddle: Jerboa",
+        "video_query": "jerboa for kids",
+        "video_title": "Jerboa videos for kids",
+    },
+    "arctic-fox": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/arctic-fox",
+        "learn_more_label": "National Geographic Kids: Arctic Fox",
+        "video_query": "arctic fox for kids",
+        "video_title": "Arctic fox videos for kids",
+    },
+    "polar-bear": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/polar-bear",
+        "learn_more_label": "National Geographic Kids: Polar Bear",
+        "video_query": "polar bear for kids",
+        "video_title": "Polar bear videos for kids",
+    },
+    "snowy-owl": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/birds/facts/snowy-owl",
+        "learn_more_label": "National Geographic Kids: Snowy Owl",
+        "video_query": "snowy owl for kids",
+        "video_title": "Snowy owl videos for kids",
+    },
+    "caribou": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/reindeer",
+        "learn_more_label": "National Geographic Kids: Reindeer/Caribou",
+        "video_query": "caribou for kids",
+        "video_title": "Caribou videos for kids",
+    },
+    "musk-ox": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/musk-ox",
+        "learn_more_label": "National Geographic Kids: Musk Ox",
+        "video_query": "musk ox for kids",
+        "video_title": "Musk ox videos for kids",
+    },
+    "arctic-hare": {
+        "learn_more_url": "https://www.natgeokids.com/uk/discover/animals/animals-facts/arctic-hare-facts/",
+        "learn_more_label": "Nat Geo Kids UK: Arctic Hare",
+        "video_query": "arctic hare for kids",
+        "video_title": "Arctic hare videos for kids",
+    },
+    "lemming": {
+        "learn_more_url": "https://kids.kiddle.co/Lemming",
+        "learn_more_label": "Kiddle: Lemming",
+        "video_query": "lemming for kids",
+        "video_title": "Lemming videos for kids",
+    },
+    "walrus": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/walrus",
+        "learn_more_label": "National Geographic Kids: Walrus",
+        "video_query": "walrus for kids",
+        "video_title": "Walrus videos for kids",
+    },
+    "narwhal": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/narwhal",
+        "learn_more_label": "National Geographic Kids: Narwhal",
+        "video_query": "narwhal for kids",
+        "video_title": "Narwhal videos for kids",
+    },
+    "arctic-wolf": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/mammals/facts/arctic-wolf",
+        "learn_more_label": "National Geographic Kids: Arctic Wolf",
+        "video_query": "arctic wolf for kids",
+        "video_title": "Arctic wolf videos for kids",
+    },
+    "atlantic-puffin": {
+        "learn_more_url": "https://kids.nationalgeographic.com/animals/birds/facts/atlantic-puffin",
+        "learn_more_label": "National Geographic Kids: Atlantic Puffin",
+        "video_query": "atlantic puffin for kids",
+        "video_title": "Atlantic puffin videos for kids",
+    },
+    "ringed-seal": {
+        "learn_more_url": "https://kids.kiddle.co/Ringed_seal",
+        "learn_more_label": "Kiddle: Ringed Seal",
+        "video_query": "ringed seal for kids",
+        "video_title": "Ringed seal videos for kids",
+    },
 }
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -1376,8 +1668,43 @@ def render_animal(biome: str, data: dict) -> str:
             f"        <div class=\"adaptation\">\n          <h3>{item['title']}</h3>\n          <p>\n            {item['text']}\n          </p>\n          <button\n            class=\"speak-button\"\n            data-speech=\"{item['text']}\"\n          >\n            ▶️ Hear this adaptation\n          </button>\n        </div>\n"
         )
     adaptations_html = "      <section class=\"adaptations\">\n" + "".join(adaptation_blocks) + "      </section>\n"
+    resource = ANIMAL_RESOURCES.get(data["slug"], {})
+    learn_more_html = ""
+    if resource.get("learn_more_url"):
+        learn_more_html = (
+            "      <section class=\"learn-more\">\n"
+            "        <h3>Keep exploring the {name}</h3>\n"
+            "        <p>\n"
+            "          <a class=\"learn-more-link\" href=\"{url}\" target=\"_blank\" rel=\"noopener\">"
+            "Learn more from {label}</a>\n"
+            "        </p>\n"
+            "      </section>\n"
+        ).format(name=data["name"], url=resource["learn_more_url"], label=resource["learn_more_label"])
+    video_html = ""
+    video_query = resource.get("video_query")
+    video_url = resource.get("video_url")
+    if video_query and not video_url:
+        video_url = f"https://www.youtube.com/embed?listType=search&list={quote_plus(video_query)}"
+    if video_url:
+        video_title = resource.get("video_title", f"{data['name']} videos for kids")
+        video_html = (
+            "      <section class=\"video-section\">\n"
+            "        <h3>Watch the {name} in action</h3>\n"
+            "        <div class=\"video-wrapper\">\n"
+            "          <iframe\n"
+            "            src=\"{url}\"\n"
+            "            title=\"{title}\"\n"
+            "            loading=\"lazy\"\n"
+            "            allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\"\n"
+            "            allowfullscreen\n"
+            "          ></iframe>\n"
+            "        </div>\n"
+            "        <p class=\"video-caption\">{title}</p>\n"
+            "      </section>\n"
+        ).format(name=data["name"], url=video_url, title=video_title)
     footer = f"    <footer>{data['footer']}</footer>\n    <script src=\"../../assets/js/script.js\"></script>\n  </body>\n</html>\n"
-    return header + "    <main class=\"container\">\n" + back_link + hero_section + adaptations_html + "    </main>\n" + footer
+    main_content = "    <main class=\"container\">\n" + back_link + hero_section + adaptations_html + learn_more_html + video_html + "    </main>\n"
+    return header + main_content + footer
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- map each animal page to a kid-friendly article and YouTube search playlist so regenerated pages include learn-more links and video embeds
- add styling for the new learn-more and video sections
- add matching resource links and embedded playlists to every biome landing page

## Testing
- python generate_animals.py
- python -m compileall generate_animals.py

------
https://chatgpt.com/codex/tasks/task_e_68caf431bef883319839d9feadfb9524