### PR TITLE
Embed curated YouTube videos on biome pages

### DIFF
--- a/biomes/desert/bark-scorpion.html
+++ b/biomes/desert/bark-scorpion.html
@@ -83,14 +83,16 @@
         <h3>Watch the Bark Scorpion in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=bark+scorpion+for+kids"
-            title="Bark scorpion videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/5ZpQ2A6yFf0"
+            title="Scorpion Facts for Kids (Homeschool Pop)"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Bark scorpion videos for kids</p>
+        <p class="video-caption">Scorpion Facts for Kids (Homeschool Pop)</p>
       </section>
     </main>
     <footer>Quiet feet and glowing armor guide the bark scorpion.</footer>

--- a/biomes/desert/dromedary-camel.html
+++ b/biomes/desert/dromedary-camel.html
@@ -83,14 +83,16 @@
         <h3>Watch the Dromedary Camel in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=dromedary+camel+for+kids"
-            title="Dromedary camel videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/JSMpK3dF0nU"
+            title="Camels for Kids"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Dromedary camel videos for kids</p>
+        <p class="video-caption">Camels for Kids</p>
       </section>
     </main>
     <footer>Camels are expert travelers of dry places.</footer>

--- a/biomes/desert/egyptian-vulture.html
+++ b/biomes/desert/egyptian-vulture.html
@@ -83,14 +83,16 @@
         <h3>Watch the Egyptian Vulture in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=egyptian+vulture+for+kids"
-            title="Egyptian vulture videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/8E2zc6xgq2E"
+            title="Animal Facts – Vulture"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Egyptian vulture videos for kids</p>
+        <p class="video-caption">Animal Facts – Vulture</p>
       </section>
     </main>
     <footer>Even leftovers become useful with a clever vulture.</footer>

--- a/biomes/desert/fennec-fox.html
+++ b/biomes/desert/fennec-fox.html
@@ -83,14 +83,16 @@
         <h3>Watch the Fennec Fox in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=fennec+fox+for+kids"
-            title="Fennec fox videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/1Qk5o7IofNw"
+            title="Fennec Fox Facts for Kids"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Fennec fox videos for kids</p>
+        <p class="video-caption">Fennec Fox Facts for Kids</p>
       </section>
     </main>
     <footer>Staying cool helps fennec foxes thrive in the desert.</footer>

--- a/biomes/desert/gila-monster.html
+++ b/biomes/desert/gila-monster.html
@@ -83,14 +83,16 @@
         <h3>Watch the Gila Monster in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=gila+monster+for+kids"
-            title="Gila monster videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/h3fQPCzJX3k"
+            title="Gila Monster (SciShow Kids)"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Gila monster videos for kids</p>
+        <p class="video-caption">Gila Monster (SciShow Kids)</p>
       </section>
     </main>
     <footer>Patience and poison give the Gila monster power.</footer>

--- a/biomes/desert/index.html
+++ b/biomes/desert/index.html
@@ -151,14 +151,16 @@
         <h3>Watch desert wildlife explore</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=desert+biome+for+kids"
-            title="Desert biome videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/Q_7qf5K7c2A"
+            title="What is the Desert? (SciShow Kids)"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Desert biome videos for kids</p>
+        <p class="video-caption">What is the Desert? (SciShow Kids)</p>
       </section>
     </main>
     <footer>Pick an animal to discover desert survival secrets!</footer>

--- a/biomes/desert/roadrunner.html
+++ b/biomes/desert/roadrunner.html
@@ -83,14 +83,16 @@
         <h3>Watch the Roadrunner in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=roadrunner+bird+for+kids"
-            title="Roadrunner videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/Kqlh4h5C6iM"
+            title="Roadrunner Facts! for Kids"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Roadrunner videos for kids</p>
+        <p class="video-caption">Roadrunner Facts! for Kids</p>
       </section>
     </main>
     <footer>Speed and smarts help roadrunners stay safe.</footer>

--- a/biomes/desert/sidewinder-rattlesnake.html
+++ b/biomes/desert/sidewinder-rattlesnake.html
@@ -83,14 +83,16 @@
         <h3>Watch the Sidewinder Rattlesnake in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=sidewinder+rattlesnake+for+kids"
-            title="Sidewinder rattlesnake videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/GK3f0ZkWZ9Q"
+            title="Rattlesnakes for Kids"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Sidewinder rattlesnake videos for kids</p>
+        <p class="video-caption">Rattlesnakes for Kids</p>
       </section>
     </main>
     <footer>Smart moves help the sidewinder stay cool.</footer>

--- a/biomes/rainforest/amazon-river-dolphin.html
+++ b/biomes/rainforest/amazon-river-dolphin.html
@@ -83,14 +83,16 @@
         <h3>Watch the Amazon River Dolphin in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=amazon+river+dolphin+for+kids"
-            title="Amazon river dolphin videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/N7qf3y_CG3o"
+            title="Amazon Dolphins (National Geographic)"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Amazon river dolphin videos for kids</p>
+        <p class="video-caption">Amazon Dolphins (National Geographic)</p>
       </section>
     </main>
     <footer>The boto proves rivers can hide colorful surprises.</footer>

--- a/biomes/rainforest/capuchin-monkey.html
+++ b/biomes/rainforest/capuchin-monkey.html
@@ -83,14 +83,16 @@
         <h3>Watch the Capuchin Monkey in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=capuchin+monkey+for+kids"
-            title="Capuchin monkey videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/tzjXfSg3x4k"
+            title="CBeebies: Andy's Wild Adventures – Capuchin Monkeys"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Capuchin monkey videos for kids</p>
+        <p class="video-caption">CBeebies: Andy's Wild Adventures – Capuchin Monkeys</p>
       </section>
     </main>
     <footer>Clever hands and teamwork keep capuchins safe.</footer>

--- a/biomes/rainforest/green-anaconda.html
+++ b/biomes/rainforest/green-anaconda.html
@@ -83,14 +83,16 @@
         <h3>Watch the Green Anaconda in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=green+anaconda+for+kids"
-            title="Green anaconda videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/4m7NwXwUgB0"
+            title="Giant Green Anaconda | Animal Fun Facts"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Green anaconda videos for kids</p>
+        <p class="video-caption">Giant Green Anaconda | Animal Fun Facts</p>
       </section>
     </main>
     <footer>Slow and steady swimming makes the anaconda successful.</footer>

--- a/biomes/rainforest/harpy-eagle.html
+++ b/biomes/rainforest/harpy-eagle.html
@@ -83,14 +83,16 @@
         <h3>Watch the Harpy Eagle in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=harpy+eagle+for+kids"
-            title="Harpy eagle videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/Y_0H8bYB8mY"
+            title="Harpy Eagle (National Geographic Kids)"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Harpy eagle videos for kids</p>
+        <p class="video-caption">Harpy Eagle (National Geographic Kids)</p>
       </section>
     </main>
     <footer>Harpy eagles are gentle giants to their chicks but fierce hunters in flight.</footer>

--- a/biomes/rainforest/index.html
+++ b/biomes/rainforest/index.html
@@ -152,14 +152,16 @@
         <h3>Watch rainforest life in motion</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=rainforest+animals+for+kids"
-            title="Rainforest animal videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/ydX5manGO20"
+            title="What is the Rainforest? (SciShow Kids)"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Rainforest animal videos for kids</p>
+        <p class="video-caption">What is the Rainforest? (SciShow Kids)</p>
       </section>
     </main>
     <footer>Pick an animal to discover rainforest superpowers!</footer>

--- a/biomes/rainforest/jaguar.html
+++ b/biomes/rainforest/jaguar.html
@@ -83,14 +83,16 @@
         <h3>Watch the Jaguar in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=jaguar+for+kids"
-            title="Jaguar videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/GJ7oHb71XNM"
+            title="Jaguars for Kids"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Jaguar videos for kids</p>
+        <p class="video-caption">Jaguars for Kids</p>
       </section>
     </main>
     <footer>Jaguars show how strength and silence work together.</footer>

--- a/biomes/rainforest/leaf-tailed-gecko.html
+++ b/biomes/rainforest/leaf-tailed-gecko.html
@@ -83,14 +83,16 @@
         <h3>Watch the Leaf-Tailed Gecko in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=leaf+tailed+gecko+for+kids"
-            title="Leaf-tailed gecko videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/FlRkZPbnKf4"
+            title="Meet the Ninja Gecko (Nat Geo WILD)"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Leaf-tailed gecko videos for kids</p>
+        <p class="video-caption">Meet the Ninja Gecko (Nat Geo WILD)</p>
       </section>
     </main>
     <footer>Sometimes the best defense is becoming invisible!</footer>

--- a/biomes/rainforest/leafcutter-ant.html
+++ b/biomes/rainforest/leafcutter-ant.html
@@ -83,14 +83,16 @@
         <h3>Watch the Leafcutter Ant in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=leafcutter+ant+for+kids"
-            title="Leafcutter ant videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/-6oKxw4o5Eo"
+            title="Leafcutter Ants: Mini-But-Mighty Farmers"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Leafcutter ant videos for kids</p>
+        <p class="video-caption">Leafcutter Ants: Mini-But-Mighty Farmers</p>
       </section>
     </main>
     <footer>Leafcutter ants prove teamwork makes mighty results.</footer>

--- a/biomes/rainforest/orangutan.html
+++ b/biomes/rainforest/orangutan.html
@@ -83,14 +83,16 @@
         <h3>Watch the Orangutan in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=orangutan+for+kids"
-            title="Orangutan videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/fm2S0k0pM-M"
+            title="Top 10 Orangutan Facts (WWF)"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Orangutan videos for kids</p>
+        <p class="video-caption">Top 10 Orangutan Facts (WWF)</p>
       </section>
     </main>
     <footer>Caring and clever orangutans remind us to protect the forest.</footer>

--- a/biomes/rainforest/poison-dart-frog.html
+++ b/biomes/rainforest/poison-dart-frog.html
@@ -83,14 +83,16 @@
         <h3>Watch the Poison Dart Frog in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=poison+dart+frog+for+kids"
-            title="Poison dart frog videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/xy3DZ3oz3FY"
+            title="SciShow Kids: Poison Dart Frogs"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Poison dart frog videos for kids</p>
+        <p class="video-caption">SciShow Kids: Poison Dart Frogs</p>
       </section>
     </main>
     <footer>Color can be a powerful rainforest shield!</footer>

--- a/biomes/rainforest/scarlet-macaw.html
+++ b/biomes/rainforest/scarlet-macaw.html
@@ -83,14 +83,16 @@
         <h3>Watch the Scarlet Macaw in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=scarlet+macaw+for+kids"
-            title="Scarlet macaw videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/3gG3b8qFzL4"
+            title="10 Amazing Macaw Facts for Kids"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Scarlet macaw videos for kids</p>
+        <p class="video-caption">10 Amazing Macaw Facts for Kids</p>
       </section>
     </main>
     <footer>Bright feathers and loud voices make macaws unforgettable.</footer>

--- a/biomes/rainforest/sloth.html
+++ b/biomes/rainforest/sloth.html
@@ -83,14 +83,16 @@
         <h3>Watch the Sloth in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=sloth+for+kids"
-            title="Sloth videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/pkv5rG0nLRk"
+            title="Sloth Facts for Kids | Classroom Learning Video"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Sloth videos for kids</p>
+        <p class="video-caption">Sloth Facts for Kids | Classroom Learning Video</p>
       </section>
     </main>
     <footer>Sometimes slow and steady wins in the rainforest!</footer>

--- a/biomes/rainforest/toucan.html
+++ b/biomes/rainforest/toucan.html
@@ -83,14 +83,16 @@
         <h3>Watch the Toucan in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=toucan+for+kids"
-            title="Toucan videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/J0G5oR7nK9g"
+            title="Toucan Fun Facts For Kids"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Toucan videos for kids</p>
+        <p class="video-caption">Toucan Fun Facts For Kids</p>
       </section>
     </main>
     <footer>That colorful beak is more than just for show!</footer>

--- a/biomes/savannah/african-elephant.html
+++ b/biomes/savannah/african-elephant.html
@@ -83,14 +83,16 @@
         <h3>Watch the African Elephant in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=african+elephant+for+kids"
-            title="African elephant videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/6Chud9o0T9g"
+            title="All About African Elephants!"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">African elephant videos for kids</p>
+        <p class="video-caption">All About African Elephants!</p>
       </section>
     </main>
     <footer>Elephants show the strength of family care.</footer>

--- a/biomes/savannah/african-wild-dog.html
+++ b/biomes/savannah/african-wild-dog.html
@@ -83,14 +83,16 @@
         <h3>Watch the African Wild Dog in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=african+wild+dog+for+kids"
-            title="African wild dog videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/4v5C2O3YHnM"
+            title="All About African Wild Dogs for Kids"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">African wild dog videos for kids</p>
+        <p class="video-caption">All About African Wild Dogs for Kids</p>
       </section>
     </main>
     <footer>Kindness keeps the painted dogs strong.</footer>

--- a/biomes/savannah/cheetah.html
+++ b/biomes/savannah/cheetah.html
@@ -83,14 +83,16 @@
         <h3>Watch the Cheetah in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=cheetah+for+kids"
-            title="Cheetah videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/G1D3r7Gd7xk"
+            title="Cheetah Facts for Kids (11 Facts)"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Cheetah videos for kids</p>
+        <p class="video-caption">Cheetah Facts for Kids (11 Facts)</p>
       </section>
     </main>
     <footer>Cheetahs are built from nose to tail for quick dashes.</footer>

--- a/biomes/savannah/giraffe.html
+++ b/biomes/savannah/giraffe.html
@@ -83,14 +83,16 @@
         <h3>Watch the Giraffe in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=giraffe+for+kids"
-            title="Giraffe videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/hme8aR7y9xk"
+            title="Giraffes for Kids"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Giraffe videos for kids</p>
+        <p class="video-caption">Giraffes for Kids</p>
       </section>
     </main>
     <footer>High heads keep giraffes safe and well fed.</footer>

--- a/biomes/savannah/hippopotamus.html
+++ b/biomes/savannah/hippopotamus.html
@@ -83,14 +83,16 @@
         <h3>Watch the Hippopotamus in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=hippopotamus+for+kids"
-            title="Hippopotamus videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/_mP8N2u8GFE"
+            title="What is a Hippo? (Kids video)"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Hippopotamus videos for kids</p>
+        <p class="video-caption">What is a Hippo? (Kids video)</p>
       </section>
     </main>
     <footer>Water and land both feel like home to hippos.</footer>

--- a/biomes/savannah/index.html
+++ b/biomes/savannah/index.html
@@ -151,14 +151,16 @@
         <h3>Watch savanna animals roam</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=savanna+animals+for+kids"
-            title="Savanna animal videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/6h8vS3Px1n8"
+            title="Savanna (Grassland) Biome | Facts for Kids"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Savanna animal videos for kids</p>
+        <p class="video-caption">Savanna (Grassland) Biome | Facts for Kids</p>
       </section>
     </main>
     <footer>Pick an animal to discover savannah survival skills!</footer>

--- a/biomes/savannah/lion.html
+++ b/biomes/savannah/lion.html
@@ -83,14 +83,16 @@
         <h3>Watch the Lion in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=lion+for+kids"
-            title="Lion videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/15o3q1P2xwQ"
+            title="Lions for Kids | All You Need to Know"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Lion videos for kids</p>
+        <p class="video-caption">Lions for Kids | All You Need to Know</p>
       </section>
     </main>
     <footer>Lions prove that sharing jobs helps everyone eat.</footer>

--- a/biomes/savannah/meerkat.html
+++ b/biomes/savannah/meerkat.html
@@ -83,14 +83,16 @@
         <h3>Watch the Meerkat in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=meerkat+for+kids"
-            title="Meerkat videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/j9wBR8d3e_Q"
+            title="All About Meerkats for Kids"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Meerkat videos for kids</p>
+        <p class="video-caption">All About Meerkats for Kids</p>
       </section>
     </main>
     <footer>Sharing chores keeps meerkat mobs happy.</footer>

--- a/biomes/savannah/ostrich.html
+++ b/biomes/savannah/ostrich.html
@@ -83,14 +83,16 @@
         <h3>Watch the Ostrich in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=ostrich+for+kids"
-            title="Ostrich videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/7F4G1bRk0nI"
+            title="Ostrich Facts for Kids (Homeschool Pop)"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Ostrich videos for kids</p>
+        <p class="video-caption">Ostrich Facts for Kids (Homeschool Pop)</p>
       </section>
     </main>
     <footer>Strong legs keep ostriches safe on open plains.</footer>

--- a/biomes/savannah/secretary-bird.html
+++ b/biomes/savannah/secretary-bird.html
@@ -83,14 +83,16 @@
         <h3>Watch the Secretary Bird in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=secretary+bird+for+kids"
-            title="Secretary bird videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/0OGh4yHifCY"
+            title="SciShow Kids: Secretary Bird"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Secretary bird videos for kids</p>
+        <p class="video-caption">SciShow Kids: Secretary Bird</p>
       </section>
     </main>
     <footer>Tall legs and sharp eyes make the secretary bird special.</footer>

--- a/biomes/savannah/warthog.html
+++ b/biomes/savannah/warthog.html
@@ -83,14 +83,16 @@
         <h3>Watch the Warthog in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=warthog+for+kids"
-            title="Warthog videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/3sQHqS3G9nI"
+            title="Warthog Facts for Kids"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Warthog videos for kids</p>
+        <p class="video-caption">Warthog Facts for Kids</p>
       </section>
     </main>
     <footer>Bravery and burrows keep warthogs safe.</footer>

--- a/biomes/savannah/wildebeest.html
+++ b/biomes/savannah/wildebeest.html
@@ -83,14 +83,16 @@
         <h3>Watch the Wildebeest in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=wildebeest+for+kids"
-            title="Wildebeest videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/5wO6A36v_TQ"
+            title="Wildebeest | BBC Earth Kids"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Wildebeest videos for kids</p>
+        <p class="video-caption">Wildebeest | BBC Earth Kids</p>
       </section>
     </main>
     <footer>Traveling together keeps wildebeest safe and fed.</footer>

--- a/biomes/savannah/zebra.html
+++ b/biomes/savannah/zebra.html
@@ -83,14 +83,16 @@
         <h3>Watch the Zebra in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=zebra+for+kids"
-            title="Zebra videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/KpYpV9UQm1Q"
+            title="Zebra Facts for Kids"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Zebra videos for kids</p>
+        <p class="video-caption">Zebra Facts for Kids</p>
       </section>
     </main>
     <footer>Zebras prove that friendship can be a superpower.</footer>

--- a/biomes/tundra/arctic-fox.html
+++ b/biomes/tundra/arctic-fox.html
@@ -83,14 +83,16 @@
         <h3>Watch the Arctic Fox in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=arctic+fox+for+kids"
-            title="Arctic fox videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/1iEwqTNtPXk"
+            title="Arctic Foxes (National Geographic Kids)"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Arctic fox videos for kids</p>
+        <p class="video-caption">Arctic Foxes (National Geographic Kids)</p>
       </section>
     </main>
     <footer>Cozy fur keeps the arctic fox comfy in cold weather.</footer>

--- a/biomes/tundra/arctic-hare.html
+++ b/biomes/tundra/arctic-hare.html
@@ -83,14 +83,16 @@
         <h3>Watch the Arctic Hare in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=arctic+hare+for+kids"
-            title="Arctic hare videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/eV8g-4bWzIo"
+            title="Learn About Arctic Hares | Fun Animal Facts"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Arctic hare videos for kids</p>
+        <p class="video-caption">Learn About Arctic Hares | Fun Animal Facts</p>
       </section>
     </main>
     <footer>Speed and camouflage help the Arctic hare survive.</footer>

--- a/biomes/tundra/atlantic-puffin.html
+++ b/biomes/tundra/atlantic-puffin.html
@@ -83,14 +83,16 @@
         <h3>Watch the Atlantic Puffin in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=atlantic+puffin+for+kids"
-            title="Atlantic puffin videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/DEanx3JV3vc"
+            title="Puffin Facts for Kids | Atlantic Puffins"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Atlantic puffin videos for kids</p>
+        <p class="video-caption">Puffin Facts for Kids | Atlantic Puffins</p>
       </section>
     </main>
     <footer>Puffins are acrobats in the air and sea.</footer>

--- a/biomes/tundra/caribou.html
+++ b/biomes/tundra/caribou.html
@@ -83,14 +83,16 @@
         <h3>Watch the Caribou in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=caribou+for+kids"
-            title="Caribou videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/ul0O3qYXSRQ"
+            title="All About Reindeer or Caribou for Kids"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Caribou videos for kids</p>
+        <p class="video-caption">All About Reindeer or Caribou for Kids</p>
       </section>
     </main>
     <footer>Caribou teach us about long-distance teamwork.</footer>

--- a/biomes/tundra/index.html
+++ b/biomes/tundra/index.html
@@ -152,14 +152,16 @@
         <h3>Watch tundra animals thrive</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=tundra+animals+for+kids"
-            title="Tundra animal videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/RT6x5GVPFG8"
+            title="What Are Tundras? (National Geographic)"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Tundra animal videos for kids</p>
+        <p class="video-caption">What Are Tundras? (National Geographic)</p>
       </section>
     </main>
     <footer>Pick an animal to discover tundra survival skills!</footer>

--- a/biomes/tundra/lemming.html
+++ b/biomes/tundra/lemming.html
@@ -83,14 +83,16 @@
         <h3>Watch the Lemming in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=lemming+for+kids"
-            title="Lemming videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/2fHYNMvcAhc"
+            title="3 Facts About Lemmings"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Lemming videos for kids</p>
+        <p class="video-caption">3 Facts About Lemmings</p>
       </section>
     </main>
     <footer>Even tiny lemmings have big survival skills.</footer>

--- a/biomes/tundra/musk-ox.html
+++ b/biomes/tundra/musk-ox.html
@@ -83,14 +83,16 @@
         <h3>Watch the Musk Ox in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=musk+ox+for+kids"
-            title="Musk ox videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/L6jCEvvAHIY"
+            title="Musk Ox for Kids | Amazing Fun Facts"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Musk ox videos for kids</p>
+        <p class="video-caption">Musk Ox for Kids | Amazing Fun Facts</p>
       </section>
     </main>
     <footer>Togetherness keeps musk oxen safe from storms and predators.</footer>

--- a/biomes/tundra/narwhal.html
+++ b/biomes/tundra/narwhal.html
@@ -83,14 +83,16 @@
         <h3>Watch the Narwhal in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=narwhal+for+kids"
-            title="Narwhal videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/MXsZg1sQYvA"
+            title="Narwhals: The Unicorns of the Sea! (Nat Geo WILD)"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Narwhal videos for kids</p>
+        <p class="video-caption">Narwhals: The Unicorns of the Sea! (Nat Geo WILD)</p>
       </section>
     </main>
     <footer>Narwhals prove the Arctic is full of wonders.</footer>

--- a/biomes/tundra/polar-bear.html
+++ b/biomes/tundra/polar-bear.html
@@ -83,14 +83,16 @@
         <h3>Watch the Polar Bear in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=polar+bear+for+kids"
-            title="Polar bear videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/--xEE7K67Xo"
+            title="All About Polar Bears for Kids (FreeSchool)"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Polar bear videos for kids</p>
+        <p class="video-caption">All About Polar Bears for Kids (FreeSchool)</p>
       </section>
     </main>
     <footer>Polar bears are perfectly built for icy adventures.</footer>

--- a/biomes/tundra/ringed-seal.html
+++ b/biomes/tundra/ringed-seal.html
@@ -83,14 +83,16 @@
         <h3>Watch the Ringed Seal in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=ringed+seal+for+kids"
-            title="Ringed seal videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/VSG-kmsSuqE"
+            title="Learn All About Seals! (Facts for Kids)"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Ringed seal videos for kids</p>
+        <p class="video-caption">Learn All About Seals! (Facts for Kids)</p>
       </section>
     </main>
     <footer>Ringed seals are masters of snowy hideouts.</footer>

--- a/biomes/tundra/snowy-owl.html
+++ b/biomes/tundra/snowy-owl.html
@@ -83,14 +83,16 @@
         <h3>Watch the Snowy Owl in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=snowy+owl+for+kids"
-            title="Snowy owl videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/5N1DJu6deo0"
+            title="Snowy Owls Facts for Kids"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Snowy owl videos for kids</p>
+        <p class="video-caption">Snowy Owls Facts for Kids</p>
       </section>
     </main>
     <footer>Snowy owls are patient watchers of the tundra.</footer>

--- a/biomes/tundra/walrus.html
+++ b/biomes/tundra/walrus.html
@@ -83,14 +83,16 @@
         <h3>Watch the Walrus in action</h3>
         <div class="video-wrapper">
           <iframe
-            src="https://www.youtube.com/embed?listType=search&list=walrus+for+kids"
-            title="Walrus videos for kids"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/r35i6WFbPa0"
+            title="Walrus | Amazing Animals"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowfullscreen
           ></iframe>
         </div>
-        <p class="video-caption">Walrus videos for kids</p>
+        <p class="video-caption">Walrus | Amazing Animals</p>
       </section>
     </main>
     <footer>Walruses love chilly waves and cozy naps on ice.</footer>


### PR DESCRIPTION
## Summary
- replace the search-based iframe on each rainforest and savannah animal page (and their biome overviews) with the provided kid-friendly YouTube embeds
- update the desert overview plus camel, fox, rattlesnake, scorpion, roadrunner, gila monster, and vulture pages to use their curated YouTube videos
- refresh the tundra overview and animals (except arctic wolf) with specific YouTube embeds that match the supplied list
- note: Arabian oryx, desert tortoise, jerboa, kangaroo rat, horned lizard, and arctic wolf still reference search URLs until PBS or other vetted embeds are available

## Testing
- not run (static HTML update)


------
https://chatgpt.com/codex/tasks/task_e_68caf74db50483319de0b9012e871f60