### PR TITLE
Add iPad-only quality review and prioritized remediation plan

### DIFF
--- a/IPAD_QUALITY_REVIEW.md
+++ b/IPAD_QUALITY_REVIEW.md
@@ -1,0 +1,98 @@
+# iPad-Only Quality Review (iPad A16, iPadOS 18.6.2)
+
+This review re-evaluates the current site assuming **100% iPad usage** (touch-first, Safari/WebKit rendering, no required mouse/keyboard).
+
+## Executive Summary
+
+The project has a strong base for first graders (large cards, visual hierarchy, simple biome navigation), but quality is currently limited by a few high-impact issues:
+
+1. Biome overview videos in biome index pages are non-functional because the iframe embed URL is missing.
+2. Touch UX is not fully optimized for iPad-only interaction patterns (tap states, gesture-safe spacing, predictable media behavior).
+3. Reading support can be improved for emerging readers with clearer “listen along” flows and chunked text.
+4. Classroom-mode features (guided navigation, quick teacher controls, offline predictability) are not yet present.
+
+## What Changes When We Target Only iPad
+
+Targeting one device family is an advantage. We can intentionally design for:
+
+- **Touch-first interactions only** (no hover reliance, clearer tap feedback).
+- **Fixed performance envelope** (A16-class hardware supports richer animation/audio while keeping 60fps).
+- **Consistent browser engine** (Safari/WebKit behavior can be tested and tuned directly).
+- **Classroom constraints** (shared devices, variable connectivity, short student attention spans).
+
+## Current Quality Snapshot
+
+### Strengths
+
+- Child-friendly card UI and consistent page patterns are already in place.
+- Content structure is predictable across biomes and animals (good for early readers).
+- Audio-read buttons already exist on animal pages.
+
+### High-Priority Gaps
+
+- Biome overview video iframes are present but missing `src`, so students cannot play those videos.
+- Link and interaction feedback is optimized more for desktop hover than touch confirmation.
+- “Opens in new tab” external links may create context switching challenges for first graders.
+- No explicit classroom-mode flow (e.g., next activity button, return-to-biome sticky action, progress cues).
+
+## iPad-Specific Next Steps (Prioritized)
+
+## P0 (Do first)
+
+1. **Repair biome overview videos**
+   - Add valid embed URLs to each biome index iframe.
+   - Keep captions and titles aligned with video source.
+
+2. **Touch target and tap feedback pass**
+   - Ensure all primary controls are comfortably tappable (Apple HIG friendly).
+   - Add clear `:active` feedback on cards/buttons so kids can tell taps registered.
+
+3. **Navigation simplification for young learners**
+   - Add a persistent, obvious “Back to biome” action on animal pages.
+   - Prevent accidental context loss when opening external links.
+
+## P1 (Next wave)
+
+4. **Reader support mode**
+   - Add “Read page aloud” to play intro + adaptations in sequence.
+   - Highlight current sentence while reading.
+   - Optional slower/faster read rate presets (“slow,” “normal”).
+
+5. **Guided learning cards**
+   - Add one simple “Try it” prompt per page (e.g., “Tap the adaptation that helps this animal hide.”).
+   - Use immediate positive feedback with audio chime and plain language.
+
+6. **Media reliability**
+   - Use poster images and explicit play buttons so blank frames are avoided.
+   - Defer heavy media loading until user taps, improving first paint and classroom reliability.
+
+## P2 (iPad-only opportunity features)
+
+7. **Classroom mode toggle**
+   - Fewer outbound links, larger type, reduced UI clutter.
+   - Optional auto-return timer to biome page for station rotation.
+
+8. **Offline-first support**
+   - Add a service worker to cache core pages/images/audio for unstable Wi‑Fi.
+   - Provide clear offline indicator (“You can still explore saved animals”).
+
+9. **Telemetry for teaching outcomes**
+   - Local-only progress markers (animals explored, facts listened to).
+   - Optional teacher export (privacy-safe summary).
+
+## Suggested Success Metrics
+
+- Students can reach an animal page from home in **≤2 taps**.
+- Tap error rate (wrong/accidental taps) falls after touch-target update.
+- “Listen” completion rate increases after adding sequential read-aloud.
+- Time-to-first-interaction remains under ~2 seconds on classroom Wi‑Fi.
+
+## Practical Build Plan
+
+1. Ship P0 fixes in one sprint (stability + touch clarity).
+2. Ship P1 reader supports next (learning outcomes).
+3. Ship P2 classroom/offline enhancements if this will be used repeatedly in classrooms.
+
+## Recommendation
+
+Proceed with an **iPad-first refinement pass** rather than broad cross-device work. The single-device target makes this site a strong candidate for polished touch UX, reliable media behavior, and classroom-ready guided learning.


### PR DESCRIPTION
### Motivation
- Add a focused evaluation that treats the site as 100% iPad usage to surface touch-first, media, and classroom pain points.
- Prioritize fixes that improve reliability and usability for early readers on iPad (video playback, tap feedback, simplified navigation, and read-aloud flows).

### Description
- Add `IPAD_QUALITY_REVIEW.md` with an executive summary, current quality snapshot, strengths, and high-priority gaps.
- Include a prioritized set of next steps grouped as `P0` (repair biome video iframes, touch targets, navigation), `P1` (reader support, guided cards, media reliability), and `P2` (classroom mode, offline caching, telemetry), plus suggested success metrics and a build plan.
- Provide concrete implementation recommendations such as adding valid `iframe` `src` values, poster images and explicit play buttons, `:active` tap feedback, and an optional service worker for offline-first support.

### Testing
- This is a documentation-only change and no automated tests were necessary, so no tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4420d64608331aa986cd4a52872dd)