### PR TITLE
Add subtle touch feedback and focus-visible accessibility styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ This project is a GitHub Pages-friendly site that helps first grade students exp
 ## Local Preview
 
 You can open `index.html` directly in a browser or use a lightweight web server (for example, `python -m http.server`) to preview and test the SpeechSynthesis audio interactions.
+
+
+## Interaction & Accessibility
+
+- **Touch feedback:** tappable cards, back links, and "Hear this adaptation" buttons include subtle active-state motion and contrast shifts so touch interactions feel acknowledged without large movement.
+- **Keyboard visibility:** `.card`, `.speak-button`, `.back-link`, and `.learn-more-link` all use a high-contrast `:focus-visible` outline so students and educators using keyboards or assistive navigation can see exactly which element is focused.
+- **Hover + focus pairing:** card elevation effects support both pointer hover and focus-based navigation to preserve discoverability across input methods.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -87,6 +87,11 @@ header p {
   box-shadow: 0 16px 30px rgba(0, 0, 0, 0.18);
 }
 
+.card:active {
+  transform: translateY(-2px) scale(0.99);
+  filter: contrast(1.02);
+}
+
 .card-image {
   padding: 1.75rem 1.75rem 0;
   display: flex;
@@ -136,6 +141,11 @@ header p {
 
 .back-link:hover {
   transform: translateX(-4px);
+}
+
+.back-link:active {
+  transform: translateX(-2px);
+  filter: contrast(1.06);
 }
 
 .hero-text {
@@ -271,11 +281,25 @@ header p {
   transform: translateY(-2px);
 }
 
+.speak-button:active {
+  transform: translateY(0) scale(0.98);
+  filter: contrast(1.05);
+}
+
 .speak-button.is-speaking {
   cursor: wait;
   opacity: 0.75;
   box-shadow: 0 6px 10px rgba(249, 168, 38, 0.28);
   transform: none;
+}
+
+.card:focus-visible,
+.speak-button:focus-visible,
+.back-link:focus-visible,
+.learn-more-link:focus-visible {
+  outline: 3px solid var(--accent-color);
+  outline-offset: 4px;
+  border-radius: 10px;
 }
 
 .biome-badge {


### PR DESCRIPTION
### Motivation

- Improve touch interaction feedback so taps on interactive elements feel acknowledged without heavy motion.
- Ensure keyboard and assistive users can clearly see focus on interactive elements to preserve accessibility.

### Description

- Added subtle `:active` states in `assets/css/styles.css` for `.card`, `.speak-button`, and `.back-link` that use small `transform` and `filter: contrast(...)` adjustments to acknowledge taps.
- Added a shared `:focus-visible` rule for `.card`, `.speak-button`, `.back-link`, and `.learn-more-link` that applies a high-contrast outline (`outline: 3px solid var(--accent-color)`) with `outline-offset` to improve keyboard visibility.
- Documented the interaction and accessibility behavior in `README.md` under a new `## Interaction & Accessibility` subsection.

### Testing

- Ran `python -m py_compile generate_animals.py` to validate Python files and the check completed successfully.
- Launched a local server with `python -m http.server` and captured an automated UI screenshot of `index.html` via Playwright to verify the styles render as expected (screenshot captured successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b450a260808331a7aa829281b7b5cd)